### PR TITLE
Add model registry utilities

### DIFF
--- a/src/outdist/__init__.py
+++ b/src/outdist/__init__.py
@@ -1,6 +1,12 @@
 """Outdist package: discrete distributions over continuous outcomes."""
 
-__all__ = ["__version__"]
+from __future__ import annotations
+
+from .models import get_model, register_model  # re-exported for convenience
+from .training.trainer import Trainer
+
+__all__ = ["__version__", "get_model", "register_model", "Trainer"]
+
 __version__ = "0.1.0"
 
-# Lazy imports could be added here when submodules are implemented.
+# Additional lazy imports could be added here when submodules are implemented.

--- a/src/outdist/configs/model.py
+++ b/src/outdist/configs/model.py
@@ -1,3 +1,27 @@
-"""Model configuration definitions."""
+"""Model configuration definitions.
 
-# Placeholder for model config dataclasses.
+The project uses lightweight dataclasses to configure models.  Each
+model architecture can define its own dedicated dataclass, but all of
+them at least store a ``name`` field so the registry can locate the
+appropriate implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+__all__ = ["ModelConfig"]
+
+
+@dataclass
+class ModelConfig:
+    """Generic configuration used to instantiate models via ``get_model``."""
+
+    name: str
+    params: Dict[str, Any] = field(default_factory=dict)
+
+    def as_kwargs(self) -> Dict[str, Any]:
+        """Return stored parameters as kwargs for the model constructor."""
+
+        return dict(self.params)

--- a/src/outdist/models/__init__.py
+++ b/src/outdist/models/__init__.py
@@ -1,3 +1,37 @@
 """Model registry and helper utilities."""
 
-# Placeholder for model registration logic.
+from __future__ import annotations
+
+from typing import Callable, Dict, Type
+
+from .base import BaseModel
+from ..configs.model import ModelConfig
+
+__all__ = ["register_model", "get_model", "MODEL_REGISTRY", "BaseModel"]
+
+
+MODEL_REGISTRY: Dict[str, Type[BaseModel]] = {}
+
+
+def register_model(name: str) -> Callable[[Type[BaseModel]], Type[BaseModel]]:
+    """Decorator to register a :class:`BaseModel` implementation."""
+
+    def decorator(cls: Type[BaseModel]) -> Type[BaseModel]:
+        MODEL_REGISTRY[name] = cls
+        return cls
+
+    return decorator
+
+
+def get_model(cfg: ModelConfig | str, **kwargs) -> BaseModel:
+    """Instantiate a model from ``cfg`` or ``name``."""
+
+    if isinstance(cfg, str):
+        name = cfg
+        params = kwargs
+    else:
+        name = cfg.name
+        params = {**cfg.as_kwargs(), **kwargs}
+
+    model_cls = MODEL_REGISTRY[name]
+    return model_cls(**params)

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,23 @@
+import torch
+from outdist.models import register_model, get_model, BaseModel
+from outdist.configs.model import ModelConfig
+
+@register_model("dummy")
+class DummyModel(BaseModel):
+    def __init__(self, out_dim: int = 1):
+        super().__init__()
+        self.fc = torch.nn.Linear(1, out_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc(x)
+
+    @classmethod
+    def default_config(cls) -> ModelConfig:
+        return ModelConfig(name="dummy", params={"out_dim": 1})
+
+
+def test_get_model_instantiates_registered_model():
+    cfg = ModelConfig(name="dummy", params={"out_dim": 2})
+    model = get_model(cfg)
+    assert isinstance(model, DummyModel)
+    assert model.fc.out_features == 2


### PR DESCRIPTION
## Summary
- add `ModelConfig` dataclass
- implement model registry with `register_model` and `get_model`
- export registry helpers from package `__init__`
- test model registration logic

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870e2fc65c483249d0909346dc845b5