### PR TITLE
Implement dummy dataset loader

### DIFF
--- a/src/outdist/__init__.py
+++ b/src/outdist/__init__.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from .models import get_model, register_model  # re-exported for convenience
 from .training.trainer import Trainer
+from .data.datasets import make_dataset
 
-__all__ = ["__version__", "get_model", "register_model", "Trainer"]
+__all__ = ["__version__", "get_model", "register_model", "Trainer", "make_dataset"]
 
 __version__ = "0.1.0"
 

--- a/src/outdist/data/datasets.py
+++ b/src/outdist/data/datasets.py
@@ -1,3 +1,41 @@
 """Dataset wrappers and utilities for creating data splits."""
 
-# Placeholder for dataset loader implementations.
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+from torch.utils.data import Dataset, TensorDataset, random_split
+
+__all__ = ["make_dataset"]
+
+
+def make_dataset(name: str, *, n_samples: int = 100, splits: Tuple[float, float, float] = (0.8, 0.1, 0.1)) -> tuple[Dataset, Dataset, Dataset]:
+    """Return train/val/test splits for the requested dataset.
+
+    Parameters
+    ----------
+    name:
+        Identifier of the dataset to create. Currently only ``"dummy"`` is
+        supported and yields randomly generated data.
+    n_samples:
+        Total number of samples to generate. Only used for ``"dummy"``.
+    splits:
+        Fractions for train/val/test. Must sum to 1.
+    """
+
+    if not torch.isclose(torch.tensor(sum(splits)), torch.tensor(1.0)):
+        raise ValueError("splits must sum to 1")
+
+    if name == "dummy":
+        x = torch.randn(n_samples, 1)
+        y = torch.randint(0, 10, (n_samples,))
+        dataset = TensorDataset(x, y)
+    else:
+        raise ValueError(f"Unknown dataset: {name}")
+
+    n_train = int(n_samples * splits[0])
+    n_val = int(n_samples * splits[1])
+    n_test = n_samples - n_train - n_val
+    train_ds, val_ds, test_ds = random_split(dataset, [n_train, n_val, n_test])
+    return train_ds, val_ds, test_ds

--- a/tests/test_make_dataset.py
+++ b/tests/test_make_dataset.py
@@ -1,0 +1,6 @@
+from outdist.data.datasets import make_dataset
+
+def test_make_dataset_splits_sum():
+    train_ds, val_ds, test_ds = make_dataset("dummy", n_samples=50, splits=(0.6, 0.2, 0.2))
+    total = len(train_ds) + len(val_ds) + len(test_ds)
+    assert total == 50


### PR DESCRIPTION
## Summary
- create a dummy dataset utility in `datasets.py`
- expose `make_dataset` in `outdist.__init__`
- add a simple test for dataset splits

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870e5101a94832485564892d65462d2