### PR TITLE
Add metrics utilities and integrate with Trainer

### DIFF
--- a/src/outdist/metrics.py
+++ b/src/outdist/metrics.py
@@ -1,3 +1,36 @@
-"""Evaluation metrics including calibration and KL divergence."""
+"""Common evaluation metrics.
 
-# Placeholder for metric implementations.
+This module exposes lightweight metric functions operating on model
+outputs.  Each metric accepts a tensor of logits ``(B, K)`` and the
+corresponding integer targets ``(B,)``.  Metrics return scalar tensors
+that can be easily converted to Python ``float`` for logging.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+import torch
+from torch.nn import functional as F
+
+__all__ = ["nll", "accuracy", "METRICS_REGISTRY"]
+
+
+def nll(logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+    """Negative log-likelihood computed via cross-entropy."""
+
+    return F.cross_entropy(logits, targets)
+
+
+def accuracy(logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+    """Top-1 accuracy of ``logits`` against ``targets``."""
+
+    preds = logits.argmax(dim=-1)
+    return (preds == targets).float().mean()
+
+
+METRICS_REGISTRY: Dict[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = {
+    "nll": nll,
+    "accuracy": accuracy,
+}
+

--- a/src/outdist/training/trainer.py
+++ b/src/outdist/training/trainer.py
@@ -9,6 +9,7 @@ from torch.utils.data import DataLoader, Dataset
 
 from ..configs import trainer as trainer_cfg
 from ..models.base import BaseModel
+from ..metrics import METRICS_REGISTRY
 
 
 @dataclass
@@ -98,8 +99,10 @@ class Trainer:
         if not metrics:
             metrics = ["nll"]
 
-        if "nll" in metrics:
-            results["nll"] = float(self.criterion(y_pred, y_true).item())
+        for name in metrics:
+            metric_fn = METRICS_REGISTRY[name]
+            value = metric_fn(y_pred, y_true)
+            results[name] = float(value.item())
 
         return results
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,15 @@
+import torch
+from outdist.metrics import nll, accuracy
+
+
+def test_nll_matches_cross_entropy():
+    logits = torch.tensor([[2.0, 1.0], [0.5, 0.5]])
+    targets = torch.tensor([0, 1])
+    expected = torch.nn.functional.cross_entropy(logits, targets)
+    assert torch.isclose(nll(logits, targets), expected)
+
+
+def test_accuracy_computation():
+    logits = torch.tensor([[2.0, 1.0], [0.5, 0.5]])
+    targets = torch.tensor([0, 1])
+    assert accuracy(logits, targets) == 0.5


### PR DESCRIPTION
## Summary
- implement `nll` and `accuracy` metrics with a small registry
- update `Trainer.evaluate` to call metrics from the registry
- add basic tests for metrics

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870e65456448324be8776634c59cd9e