### PR TITLE
Implement basic binning scheme utilities

### DIFF
--- a/src/outdist/data/binning.py
+++ b/src/outdist/data/binning.py
@@ -1,3 +1,67 @@
 """Binning schemes for discretising continuous targets."""
 
-# Placeholder for BinningScheme classes.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch
+
+__all__ = ["BinningScheme", "EqualWidthBinning", "QuantileBinning"]
+
+
+@dataclass
+class BinningScheme:
+    """Map continuous values to discrete bin indices via fixed edges."""
+
+    edges: torch.Tensor
+
+    def __post_init__(self) -> None:
+        if self.edges.ndim != 1:
+            raise ValueError("edges must be 1D")
+        if self.edges.numel() < 2:
+            raise ValueError("edges must contain at least two values")
+        if not torch.all(self.edges[1:] > self.edges[:-1]):
+            raise ValueError("edges must be strictly increasing")
+        # Ensure floating dtype for subsequent computations
+        self.edges = self.edges.to(dtype=torch.get_default_dtype())
+
+    @property
+    def n_bins(self) -> int:
+        """Number of discrete bins."""
+
+        return self.edges.numel() - 1
+
+    # ------------------------------------------------------------------
+    def to_index(self, y: torch.Tensor) -> torch.Tensor:
+        """Return integer bin indices for ``y``."""
+
+        idx = torch.bucketize(y, self.edges[1:], right=True)
+        return idx.clamp(max=self.n_bins - 1)
+
+    def bin_edges(self, idx: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Return ``(lower, upper)`` edges for bins ``idx``."""
+
+        return self.edges[idx], self.edges[idx + 1]
+
+    def centers(self) -> torch.Tensor:
+        """Return bin center locations."""
+
+        return 0.5 * (self.edges[:-1] + self.edges[1:])
+
+
+class EqualWidthBinning(BinningScheme):
+    """Uniform bin widths between ``start`` and ``end``."""
+
+    def __init__(self, start: float, end: float, n_bins: int) -> None:
+        edges = torch.linspace(start, end, n_bins + 1)
+        super().__init__(edges=edges)
+
+
+class QuantileBinning(BinningScheme):
+    """Bins based on quantiles of ``data``."""
+
+    def __init__(self, data: torch.Tensor, n_bins: int) -> None:
+        probs = torch.linspace(0, 1, n_bins + 1, device=data.device)
+        edges = torch.quantile(data.flatten(), probs)
+        super().__init__(edges=edges)

--- a/tests/test_binning_scheme.py
+++ b/tests/test_binning_scheme.py
@@ -1,0 +1,19 @@
+import torch
+from outdist.data.binning import BinningScheme, EqualWidthBinning, QuantileBinning
+
+
+def test_equal_width_to_index():
+    scheme = EqualWidthBinning(0.0, 3.0, n_bins=3)
+    y = torch.tensor([-0.5, 0.0, 0.5, 1.0, 2.9, 3.0])
+    idx = scheme.to_index(y)
+    assert idx.tolist() == [0, 0, 0, 1, 2, 2]
+
+
+def test_quantile_binning_edges():
+    data = torch.linspace(0, 1, 100)
+    scheme = QuantileBinning(data, n_bins=4)
+    # Edges should span the min and max of the data
+    assert torch.isclose(scheme.edges[0], data.min())
+    assert torch.isclose(scheme.edges[-1], data.max())
+    # Number of bins should be n_bins
+    assert scheme.n_bins == 4


### PR DESCRIPTION
## Summary
- add `BinningScheme` with equal-width and quantile implementations
- test discrete binning utilities

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870e8408c3c8324a237500768d8bc5a