### PR TITLE
Add basic loss utilities

### DIFF
--- a/src/outdist/losses.py
+++ b/src/outdist/losses.py
@@ -1,3 +1,14 @@
 """Loss functions such as cross-entropy or CRPS."""
 
-# Placeholder for loss function implementations.
+from __future__ import annotations
+
+import torch
+from torch.nn import functional as F
+
+__all__ = ["cross_entropy"]
+
+
+def cross_entropy(logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+    """Return cross-entropy loss for ``logits`` and ``targets``."""
+
+    return F.cross_entropy(logits, targets)

--- a/src/outdist/training/trainer.py
+++ b/src/outdist/training/trainer.py
@@ -10,6 +10,7 @@ from torch.utils.data import DataLoader, Dataset
 from ..configs import trainer as trainer_cfg
 from ..models.base import BaseModel
 from ..metrics import METRICS_REGISTRY
+from ..losses import cross_entropy
 
 
 @dataclass
@@ -27,7 +28,7 @@ class Trainer:
     def __init__(self, cfg: trainer_cfg.TrainerConfig) -> None:
         self.cfg = cfg
         self.device = torch.device(cfg.device)
-        self.criterion = nn.CrossEntropyLoss()
+        self.loss_fn = cross_entropy
 
     # ------------------------------------------------------------------
     # Training
@@ -58,7 +59,7 @@ class Trainer:
 
                 optimizer.zero_grad()
                 logits = model(x)
-                loss = self.criterion(logits, y)
+                loss = self.loss_fn(logits, y)
                 loss.backward()
                 optimizer.step()
 
@@ -117,7 +118,7 @@ class Trainer:
                 x = x.to(self.device)
                 y = y.to(self.device)
                 logits = model(x)
-                _ = self.criterion(logits, y)
+                _ = self.loss_fn(logits, y)
 
 
 

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,0 +1,9 @@
+import torch
+from outdist.losses import cross_entropy
+
+
+def test_cross_entropy_matches_pytorch():
+    logits = torch.tensor([[1.0, 2.0], [0.5, -1.0]])
+    targets = torch.tensor([1, 0])
+    expected = torch.nn.functional.cross_entropy(logits, targets)
+    assert torch.isclose(cross_entropy(logits, targets), expected)


### PR DESCRIPTION
## Summary
- implement a `cross_entropy` loss helper per project design
- call this helper from `Trainer`
- test the loss function

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870f6944b8083249cd72be37d2ba9a2