### PR TITLE
Implement configs

### DIFF
--- a/src/outdist/configs/__init__.py
+++ b/src/outdist/configs/__init__.py
@@ -1,0 +1,6 @@
+from .base import BaseConfig
+from .model import ModelConfig
+from .trainer import TrainerConfig
+from .data import DataConfig
+
+__all__ = ["BaseConfig", "ModelConfig", "TrainerConfig", "DataConfig"]

--- a/src/outdist/configs/base.py
+++ b/src/outdist/configs/base.py
@@ -1,3 +1,18 @@
 """Base configuration objects for the project."""
 
-# Placeholder for dataclass or pydantic model definitions.
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict
+
+__all__ = ["BaseConfig"]
+
+
+@dataclass
+class BaseConfig:
+    """Base class for configuration dataclasses."""
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return the configuration as a plain dictionary."""
+
+        return asdict(self)

--- a/src/outdist/configs/data.py
+++ b/src/outdist/configs/data.py
@@ -1,3 +1,24 @@
 """Data loading and preprocessing configuration definitions."""
 
-# Placeholder for data configuration dataclasses.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from .base import BaseConfig
+
+__all__ = ["DataConfig"]
+
+
+@dataclass
+class DataConfig(BaseConfig):
+    """Configuration options for dataset creation."""
+
+    name: str = "dummy"
+    n_samples: int = 100
+    splits: Tuple[float, float, float] = (0.8, 0.1, 0.1)
+
+    def as_kwargs(self) -> Dict[str, object]:
+        """Return arguments for :func:`outdist.data.datasets.make_dataset`."""
+
+        return {"n_samples": self.n_samples, "splits": self.splits}

--- a/src/outdist/configs/model.py
+++ b/src/outdist/configs/model.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict
 
+from .base import BaseConfig
+
 __all__ = ["ModelConfig"]
 
 
 @dataclass
-class ModelConfig:
+class ModelConfig(BaseConfig):
     """Generic configuration used to instantiate models via ``get_model``."""
 
     name: str

--- a/src/outdist/configs/trainer.py
+++ b/src/outdist/configs/trainer.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .base import BaseConfig
+
 __all__ = ["TrainerConfig"]
 
 @dataclass
-class TrainerConfig:
+class TrainerConfig(BaseConfig):
     """Configuration options for :class:`~outdist.training.trainer.Trainer`."""
 
     batch_size: int = 32


### PR DESCRIPTION
## Summary
- implement basic BaseConfig, DataConfig, and extend existing configs
- re-export configuration classes via configs/__init__.py

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687182828d54832494d151d8b99def87