### PR TITLE
Add simple MLP model

### DIFF
--- a/src/outdist/models/__init__.py
+++ b/src/outdist/models/__init__.py
@@ -35,3 +35,8 @@ def get_model(cfg: ModelConfig | str, **kwargs) -> BaseModel:
 
     model_cls = MODEL_REGISTRY[name]
     return model_cls(**params)
+
+# ------------------------------------------------------------------
+# Import built-in model implementations so they register themselves
+from . import mlp  # noqa: F401
+

--- a/src/outdist/models/mlp.py
+++ b/src/outdist/models/mlp.py
@@ -1,0 +1,38 @@
+"""Simple multilayer perceptron model."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import torch
+from torch import nn
+
+from .base import BaseModel
+from ..configs.model import ModelConfig
+from ..utils import make_mlp
+from . import register_model
+
+
+@register_model("mlp")
+class MLP(BaseModel):
+    """Plain MLP mapping ``x`` to logits over discretised outcomes."""
+
+    def __init__(
+        self,
+        in_dim: int = 1,
+        out_dim: int = 10,
+        hidden_dims: int | Sequence[int] = (32, 32),
+    ) -> None:
+        super().__init__()
+        self.net = make_mlp(in_dim, out_dim, hidden_dims)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+    @classmethod
+    def default_config(cls) -> ModelConfig:
+        return ModelConfig(
+            name="mlp", params={"in_dim": 1, "out_dim": 10, "hidden_dims": [32, 32]}
+        )
+
+

--- a/tests/test_mlp_model.py
+++ b/tests/test_mlp_model.py
@@ -1,0 +1,17 @@
+import torch
+from outdist.models import get_model
+from outdist.models.mlp import MLP
+
+
+def test_mlp_forward_shape():
+    model = get_model("mlp", in_dim=2, out_dim=3, hidden_dims=[4])
+    x = torch.randn(5, 2)
+    logits = model(x)
+    assert logits.shape == (5, 3)
+
+
+def test_default_config_instantiates_mlp():
+    cfg = MLP.default_config()
+    model = get_model(cfg)
+    assert isinstance(model, MLP)
+


### PR DESCRIPTION
## Summary
- implement an `MLP` model using the existing framework
- register the new model automatically
- test that the model can be constructed and forwards correctly

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687185ef9bfc832484dbb7b267dbba55