### PR TITLE
Add binning strategy support to Trainer

### DIFF
--- a/src/outdist/cli/train.py
+++ b/src/outdist/cli/train.py
@@ -7,6 +7,7 @@ import argparse
 from ..configs.model import ModelConfig
 from ..configs.trainer import TrainerConfig
 from ..data.datasets import make_dataset
+from ..data.binning import EqualWidthBinning
 from ..models import get_model
 from ..training.trainer import Trainer
 
@@ -34,8 +35,9 @@ def main(argv: list[str] | None = None) -> None:
     trainer = Trainer(
         TrainerConfig(batch_size=args.batch_size, max_epochs=args.epochs)
     )
+    binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
     model = get_model(ModelConfig(name=args.model))
-    trainer.fit(model, train_ds, val_ds)
+    trainer.fit(model, binning, train_ds, val_ds)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/src/outdist/data/binning.py
+++ b/src/outdist/data/binning.py
@@ -26,6 +26,12 @@ class BinningScheme:
         # Ensure floating dtype for subsequent computations
         self.edges = self.edges.to(dtype=torch.get_default_dtype())
 
+    # ------------------------------------------------------------------
+    def fit(self, data: torch.Tensor) -> "BinningScheme":
+        """Return ``self`` for API compatibility."""
+
+        return self
+
     @property
     def n_bins(self) -> int:
         """Number of discrete bins."""

--- a/src/outdist/evaluation/evaluator.py
+++ b/src/outdist/evaluation/evaluator.py
@@ -17,6 +17,7 @@ from torch.utils.data import Dataset, Subset
 from ..configs.trainer import TrainerConfig
 from ..models.base import BaseModel
 from ..training.trainer import Trainer
+from ..data.binning import EqualWidthBinning
 
 __all__ = ["CVFoldResult", "cross_validate"]
 
@@ -75,7 +76,8 @@ def cross_validate(
     for fold, (train_ds, val_ds) in enumerate(_split_dataset(dataset, k_folds), start=1):
         trainer = Trainer(trainer_cfg)
         model = model_factory()
-        ckpt = trainer.fit(model, train_ds, val_ds)
+        binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
+        ckpt = trainer.fit(model, binning, train_ds, val_ds)
         metrics_dict = trainer.evaluate(ckpt.model, val_ds, metrics=metrics)
         results.append(CVFoldResult(fold=fold, metrics=metrics_dict))
 

--- a/tests/test_trainer_binning.py
+++ b/tests/test_trainer_binning.py
@@ -1,0 +1,40 @@
+import torch
+from outdist.training.trainer import Trainer
+from outdist.configs.trainer import TrainerConfig
+from outdist.data.datasets import make_dataset
+from outdist.data.binning import BinningScheme
+from outdist.models import register_model, BaseModel
+from outdist.configs.model import ModelConfig
+
+
+class DummyBinning(BinningScheme):
+    def __init__(self):
+        super().__init__(edges=torch.tensor([0.0, 1.0]))
+        self.fit_called = False
+
+    def fit(self, data: torch.Tensor) -> "DummyBinning":
+        self.fit_called = True
+        return self
+
+
+@register_model("trainer_dummy")
+class DummyModel(BaseModel):
+    def __init__(self, out_dim: int = 10):
+        super().__init__()
+        self.fc = torch.nn.Linear(1, out_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc(x)
+
+    @classmethod
+    def default_config(cls) -> ModelConfig:
+        return ModelConfig(name="trainer_dummy", params={"out_dim": 10})
+
+
+def test_trainer_fits_binning_before_training():
+    train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
+    trainer = Trainer(TrainerConfig(max_epochs=0))
+    model = DummyModel(out_dim=10)
+    binning = DummyBinning()
+    trainer.fit(model, binning, train_ds, val_ds)
+    assert binning.fit_called


### PR DESCRIPTION
## Summary
- add a `fit` method to `BinningScheme`
- refactor `Trainer.fit` to accept a binning strategy
- update CLI and evaluator to pass a binning scheme
- add unit test covering binning strategy integration

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687199d562b88324b5c00ef2d8ac3a4f