### PR TITLE
Add logistic regression baseline model

### DIFF
--- a/src/outdist/models/__init__.py
+++ b/src/outdist/models/__init__.py
@@ -39,4 +39,5 @@ def get_model(cfg: ModelConfig | str, **kwargs) -> BaseModel:
 # ------------------------------------------------------------------
 # Import built-in model implementations so they register themselves
 from . import mlp  # noqa: F401
+from . import logistic_regression  # noqa: F401
 

--- a/src/outdist/models/logistic_regression.py
+++ b/src/outdist/models/logistic_regression.py
@@ -1,0 +1,26 @@
+"""Logistic regression baseline model."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from .base import BaseModel
+from ..configs.model import ModelConfig
+from . import register_model
+
+
+@register_model("logreg")
+class LogisticRegression(BaseModel):
+    """Linear model mapping ``x`` to logits over discretised outcomes."""
+
+    def __init__(self, in_dim: int = 1, out_dim: int = 10) -> None:
+        super().__init__()
+        self.linear = nn.Linear(in_dim, out_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+    @classmethod
+    def default_config(cls) -> ModelConfig:
+        return ModelConfig(name="logreg", params={"in_dim": 1, "out_dim": 10})

--- a/tests/test_logistic_regression_model.py
+++ b/tests/test_logistic_regression_model.py
@@ -1,0 +1,16 @@
+import torch
+from outdist.models import get_model
+from outdist.models.logistic_regression import LogisticRegression
+
+
+def test_logreg_forward_shape():
+    model = get_model("logreg", in_dim=3, out_dim=4)
+    x = torch.randn(2, 3)
+    logits = model(x)
+    assert logits.shape == (2, 4)
+
+
+def test_default_config_instantiates_logreg():
+    cfg = LogisticRegression.default_config()
+    model = get_model(cfg)
+    assert isinstance(model, LogisticRegression)


### PR DESCRIPTION
## Summary
- implement a simple logistic regression model
- auto-register the new model
- test logistic regression forward pass and default config

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871b4f782d08324a202447a573adac6