### PR TITLE
Add Gaussian location-scale baseline

### DIFF
--- a/src/outdist/models/__init__.py
+++ b/src/outdist/models/__init__.py
@@ -40,4 +40,5 @@ def get_model(cfg: ModelConfig | str, **kwargs) -> BaseModel:
 # Import built-in model implementations so they register themselves
 from . import mlp  # noqa: F401
 from . import logistic_regression  # noqa: F401
+from . import gaussian_ls  # noqa: F401
 

--- a/src/outdist/models/gaussian_ls.py
+++ b/src/outdist/models/gaussian_ls.py
@@ -1,0 +1,50 @@
+"""Gaussian location-scale baseline model."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import nn
+
+from .base import BaseModel
+from ..configs.model import ModelConfig
+from . import register_model
+
+
+@register_model("gaussian_ls")
+class GaussianLocationScale(BaseModel):
+    """Predict a Gaussian distribution then integrate over bin edges."""
+
+    def __init__(
+        self,
+        in_dim: int = 1,
+        start: float = 0.0,
+        end: float = 1.0,
+        n_bins: int = 10,
+    ) -> None:
+        super().__init__()
+        self.mean_head = nn.Linear(in_dim, 1)
+        self.log_std_head = nn.Linear(in_dim, 1)
+        edges = torch.linspace(start, end, n_bins + 1)
+        self.register_buffer("bin_edges", edges)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        mu = self.mean_head(x).squeeze(-1)
+        log_std = self.log_std_head(x).squeeze(-1)
+        std = log_std.exp()
+        edges = self.bin_edges
+        # compute CDF at each bin edge
+        z = (edges.unsqueeze(0) - mu.unsqueeze(1)) / (std.unsqueeze(1) * math.sqrt(2))
+        cdf = 0.5 * (1 + torch.erf(z))
+        probs = cdf[..., 1:] - cdf[..., :-1]
+        eps = torch.finfo(probs.dtype).tiny
+        logits = torch.log(probs.clamp_min(eps))
+        return logits
+
+    @classmethod
+    def default_config(cls) -> ModelConfig:
+        return ModelConfig(
+            name="gaussian_ls",
+            params={"in_dim": 1, "start": 0.0, "end": 1.0, "n_bins": 10},
+        )

--- a/tests/test_gaussian_ls_model.py
+++ b/tests/test_gaussian_ls_model.py
@@ -1,0 +1,16 @@
+import torch
+from outdist.models import get_model
+from outdist.models.gaussian_ls import GaussianLocationScale
+
+
+def test_gaussian_ls_forward_shape():
+    model = get_model("gaussian_ls", in_dim=2, start=0.0, end=1.0, n_bins=5)
+    x = torch.randn(4, 2)
+    logits = model(x)
+    assert logits.shape == (4, 5)
+
+
+def test_default_config_instantiates_gaussian_ls():
+    cfg = GaussianLocationScale.default_config()
+    model = get_model(cfg)
+    assert isinstance(model, GaussianLocationScale)


### PR DESCRIPTION
## Summary
- add `GaussianLocationScale` model that predicts mean and scale then converts to discretised logits
- register the model in the model registry
- test the Gaussian location-scale model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871b7133d8083248f0c6ce10be691bb