### PR TITLE
Add trainer tests for models

### DIFF
--- a/src/outdist/training/trainer.py
+++ b/src/outdist/training/trainer.py
@@ -52,7 +52,10 @@ class Trainer:
             binning.fit(y_all)
 
         model.to(self.device)
-        optimizer = torch.optim.Adam(model.parameters(), lr=self.cfg.lr)
+        params = list(model.parameters())
+        optimizer = (
+            torch.optim.Adam(params, lr=self.cfg.lr) if params else None
+        )
         train_loader = DataLoader(train_ds, batch_size=self.cfg.batch_size, shuffle=True)
         val_loader = (
             DataLoader(val_ds, batch_size=self.cfg.batch_size)
@@ -67,11 +70,13 @@ class Trainer:
                 x = x.to(self.device)
                 y = y.to(self.device)
 
-                optimizer.zero_grad()
+                if optimizer is not None:
+                    optimizer.zero_grad()
                 logits = model(x)
                 loss = self.loss_fn(logits, y)
-                loss.backward()
-                optimizer.step()
+                if optimizer is not None:
+                    loss.backward()
+                    optimizer.step()
 
             if val_loader is not None:
                 self._run_validation(model, val_loader)

--- a/tests/test_trainer_models.py
+++ b/tests/test_trainer_models.py
@@ -1,0 +1,62 @@
+import torch
+import pytest
+
+from outdist.training.trainer import Trainer
+from outdist.configs.trainer import TrainerConfig
+from outdist.data.datasets import make_dataset
+from outdist.data.binning import EqualWidthBinning
+from outdist.models import get_model
+
+
+MODEL_CONFIGS = [
+    ("mlp", {"in_dim": 1, "out_dim": 10, "hidden_dims": [4]}),
+    ("logreg", {"in_dim": 1, "out_dim": 10}),
+    ("gaussian_ls", {"in_dim": 1, "start": 0.0, "end": 1.0, "n_bins": 10}),
+    (
+        "mdn",
+        {"in_dim": 1, "start": 0.0, "end": 1.0, "n_bins": 10, "n_components": 2, "hidden_dims": [4]},
+    ),
+    (
+        "logistic_mixture",
+        {
+            "in_dim": 1,
+            "start": 0.0,
+            "end": 1.0,
+            "n_bins": 10,
+            "n_components": 2,
+            "hidden_dims": [4],
+        },
+    ),
+    (
+        "ckde",
+        {"in_dim": 1, "start": 0.0, "end": 1.0, "n_bins": 10, "x_bandwidth": 0.5, "y_bandwidth": 0.1},
+    ),
+    (
+        "quantile_rf",
+        {
+            "in_dim": 1,
+            "start": 0.0,
+            "end": 1.0,
+            "n_bins": 10,
+            "n_estimators": 5,
+            "random_state": 0,
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize("name, kwargs", MODEL_CONFIGS)
+def test_model_can_train_with_trainer(name: str, kwargs: dict) -> None:
+    train_ds, val_ds, _ = make_dataset("dummy", n_samples=20)
+    trainer = Trainer(TrainerConfig(max_epochs=1, batch_size=4))
+    binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
+    model = get_model(name, **kwargs)
+
+    if name in {"ckde", "quantile_rf"}:
+        loader = torch.utils.data.DataLoader(train_ds, batch_size=len(train_ds))
+        x_train, y_train = next(iter(loader))
+        model.fit(x_train, y_train)
+
+    ckpt = trainer.fit(model, binning, train_ds, val_ds)
+    assert ckpt.epoch == 1
+    assert isinstance(ckpt.model, type(model))


### PR DESCRIPTION
## Summary
- allow training models with no parameters by skipping optimizer setup
- add tests ensuring each model trains with `Trainer`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ca9530808324922b774537094b8c