### PR TITLE
Add evidential network implementation

### DIFF
--- a/src/outdist/dirichlet.py
+++ b/src/outdist/dirichlet.py
@@ -1,0 +1,23 @@
+"""Utilities for working with Dirichlet distributions."""
+
+from __future__ import annotations
+
+import torch
+
+__all__ = ["total_uncertainty", "epistemic_entropy"]
+
+
+def total_uncertainty(alpha: torch.Tensor) -> torch.Tensor:
+    """Return 1/S-based uncertainty measure (lower is more confident)."""
+
+    K = alpha.size(-1)
+    S = alpha.sum(-1)
+    return K / (S + 1)
+
+
+def epistemic_entropy(alpha: torch.Tensor) -> torch.Tensor:
+    """Return entropy of the expected categorical distribution."""
+
+    S = alpha.sum(-1, keepdim=True)
+    p = alpha / S
+    return (-p * p.log()).sum(-1)

--- a/src/outdist/losses.py
+++ b/src/outdist/losses.py
@@ -4,11 +4,26 @@ from __future__ import annotations
 
 import torch
 from torch.nn import functional as F
+from torch.special import digamma
 
-__all__ = ["cross_entropy"]
+__all__ = ["cross_entropy", "evidential_loss"]
 
 
 def cross_entropy(logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
     """Return cross-entropy loss for ``logits`` and ``targets``."""
 
     return F.cross_entropy(logits, targets)
+
+
+def evidential_loss(
+    alpha: torch.Tensor, targets: torch.Tensor, lam: float = 1.0
+) -> torch.Tensor:
+    """Loss for evidential classification with Dirichlet outputs."""
+
+    n_bins = alpha.size(-1)
+    t = F.one_hot(targets, num_classes=n_bins).to(dtype=alpha.dtype)
+    S = alpha.sum(-1, keepdim=True)
+    el = (t * (digamma(S) - digamma(alpha))).sum(-1)
+    kl = torch.lgamma(alpha.sum(-1)) - torch.lgamma(torch.tensor(n_bins, dtype=alpha.dtype))
+    kl -= (torch.lgamma(alpha) - torch.lgamma(torch.ones_like(alpha))).sum(-1)
+    return (el + lam * kl).mean()

--- a/src/outdist/models/__init__.py
+++ b/src/outdist/models/__init__.py
@@ -45,4 +45,5 @@ from . import mdn  # noqa: F401
 from . import quantile_rf  # noqa: F401
 from . import ckde  # noqa: F401
 from . import logistic_mixture  # noqa: F401
+from . import evidential  # noqa: F401
 

--- a/src/outdist/models/evidential.py
+++ b/src/outdist/models/evidential.py
@@ -1,3 +1,49 @@
 """Evidential neural network architecture."""
 
-# Placeholder for evidential model implementation.
+from __future__ import annotations
+
+from typing import Sequence
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from .base import BaseModel
+from ..configs.model import ModelConfig
+from ..utils import make_mlp
+from . import register_model
+
+
+@register_model("evidential")
+class EvidentialNet(BaseModel):
+    """Predict Dirichlet concentration parameters for categorical outcomes."""
+
+    def __init__(
+        self,
+        in_dim: int = 1,
+        n_bins: int = 10,
+        hidden_dims: int | Sequence[int] = (128, 128),
+    ) -> None:
+        super().__init__()
+        if isinstance(hidden_dims, int):
+            hidden_dims = [hidden_dims]
+        backbone_dims = list(hidden_dims[:-1])
+        last_dim = hidden_dims[-1]
+        self.backbone = make_mlp(in_dim, last_dim, backbone_dims)
+        self.evidence_head = nn.Linear(last_dim, n_bins)
+
+    def forward(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
+        features = self.backbone(x)
+        evidence = F.softplus(self.evidence_head(features))
+        alpha = evidence + 1.0
+        S = alpha.sum(-1, keepdim=True)
+        probs = alpha / S
+        logits = probs.log()
+        return {"alpha": alpha, "probs": probs, "logits": logits, "S": S}
+
+    @classmethod
+    def default_config(cls) -> ModelConfig:
+        return ModelConfig(
+            name="evidential",
+            params={"in_dim": 1, "n_bins": 10, "hidden_dims": [128, 128]},
+        )

--- a/tests/test_evidential_model.py
+++ b/tests/test_evidential_model.py
@@ -1,0 +1,33 @@
+import torch
+from outdist.models import get_model
+from outdist.models.evidential import EvidentialNet
+from outdist.losses import evidential_loss
+from outdist.training.trainer import Trainer
+from outdist.configs.trainer import TrainerConfig
+from outdist.data.datasets import make_dataset
+from outdist.data.binning import EqualWidthBinning
+
+
+def test_evidential_forward_shapes():
+    model = get_model("evidential", in_dim=2, n_bins=3, hidden_dims=[4, 4])
+    x = torch.randn(5, 2)
+    out = model(x)
+    assert out["alpha"].shape == (5, 3)
+    assert out["probs"].shape == (5, 3)
+    assert out["logits"].shape == (5, 3)
+
+
+def test_evidential_loss_uniform_prior():
+    alpha = torch.tensor([[1.0, 1.0]])
+    loss = evidential_loss(alpha, torch.tensor([0]), lam=0.0)
+    assert torch.isclose(loss, torch.tensor(1.0))
+
+
+def test_evidential_model_trains():
+    train_ds, val_ds, _ = make_dataset("dummy", n_samples=20)
+    trainer = Trainer(TrainerConfig(max_epochs=1, batch_size=4), loss_fn=evidential_loss)
+    binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
+    model = get_model("evidential", in_dim=1, n_bins=10, hidden_dims=[4, 4])
+    ckpt = trainer.fit(model, binning, train_ds, val_ds)
+    assert ckpt.epoch == 1
+    assert isinstance(ckpt.model, EvidentialNet)

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,5 +1,5 @@
 import torch
-from outdist.losses import cross_entropy
+from outdist.losses import cross_entropy, evidential_loss
 
 
 def test_cross_entropy_matches_pytorch():
@@ -7,3 +7,9 @@ def test_cross_entropy_matches_pytorch():
     targets = torch.tensor([1, 0])
     expected = torch.nn.functional.cross_entropy(logits, targets)
     assert torch.isclose(cross_entropy(logits, targets), expected)
+
+
+def test_evidential_loss_simple_case():
+    alpha = torch.tensor([[1.0, 1.0]])
+    loss = evidential_loss(alpha, torch.tensor([0]), lam=0.0)
+    assert torch.isclose(loss, torch.tensor(1.0))

--- a/tests/test_trainer_models.py
+++ b/tests/test_trainer_models.py
@@ -42,6 +42,7 @@ MODEL_CONFIGS = [
             "random_state": 0,
         },
     ),
+    ("evidential", {"in_dim": 1, "n_bins": 10, "hidden_dims": [4, 4]}),
 ]
 
 


### PR DESCRIPTION
## Summary
- implement evidential neural network and register it
- extend losses with evidential_loss and expose Dirichlet helpers
- allow Trainer to handle dict outputs and custom loss
- update tests and add new unit tests for evidential model

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f1bfe6408324a9e44a86b3b322ed