### PR TITLE
Add calibration framework with Dirichlet calibrator

### DIFF
--- a/src/outdist/__init__.py
+++ b/src/outdist/__init__.py
@@ -5,8 +5,17 @@ from __future__ import annotations
 from .models import get_model, register_model  # re-exported for convenience
 from .training.trainer import Trainer
 from .data.datasets import make_dataset
+from .calibration import get_calibrator, register_calibrator
 
-__all__ = ["__version__", "get_model", "register_model", "Trainer", "make_dataset"]
+__all__ = [
+    "__version__",
+    "get_model",
+    "register_model",
+    "get_calibrator",
+    "register_calibrator",
+    "Trainer",
+    "make_dataset",
+]
 
 __version__ = "0.1.0"
 

--- a/src/outdist/calibration/__init__.py
+++ b/src/outdist/calibration/__init__.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, Type
+
+import torch
+from torch import nn
+
+from ..configs.calibration import CalibratorConfig
+
+__all__ = [
+    "register_calibrator",
+    "get_calibrator",
+    "CALIBRATOR_REGISTRY",
+    "BaseCalibrator",
+]
+
+CALIBRATOR_REGISTRY: Dict[str, Type["BaseCalibrator"]] = {}
+
+
+def register_calibrator(name: str) -> Callable[[Type["BaseCalibrator"]], Type["BaseCalibrator"]]:
+    """Decorator to register a :class:`BaseCalibrator` implementation."""
+
+    def decorator(cls: Type[BaseCalibrator]) -> Type[BaseCalibrator]:
+        CALIBRATOR_REGISTRY[name] = cls
+        return cls
+
+    return decorator
+
+
+def get_calibrator(cfg: CalibratorConfig | str, **kwargs) -> "BaseCalibrator":
+    """Instantiate a calibrator from ``cfg`` or ``name``."""
+
+    if isinstance(cfg, str):
+        name = cfg
+        params = kwargs
+    else:
+        name = cfg.name
+        params = {**cfg.as_kwargs(), **kwargs}
+    cls = CALIBRATOR_REGISTRY[name]
+    return cls(**params)
+
+
+class BaseCalibrator(nn.Module):
+    """Base class for calibrators mapping probabilities to probabilities."""
+
+    _abstract = True
+
+    def forward(self, probs: torch.Tensor) -> torch.Tensor:  # pragma: no cover - abstract method
+        raise NotImplementedError
+
+    def fit(self, probs: torch.Tensor, y: torch.Tensor) -> "BaseCalibrator":  # pragma: no cover - abstract method
+        raise NotImplementedError
+
+
+# Import built-in calibrators so they register themselves
+from . import dirichlet  # noqa: F401

--- a/src/outdist/calibration/dirichlet.py
+++ b/src/outdist/calibration/dirichlet.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from torch.special import digamma
+
+from . import register_calibrator, BaseCalibrator
+
+__all__ = ["DirichletCalibrator"]
+
+
+@register_calibrator("dirichlet")
+class DirichletCalibrator(BaseCalibrator):
+    """Post-hoc Dirichlet calibrator from Kull et al. 2019."""
+
+    def __init__(self, n_bins: int, l2: float = 1e-3) -> None:
+        super().__init__()
+        self.W = nn.Parameter(torch.eye(n_bins))
+        self.b = nn.Parameter(torch.zeros(n_bins))
+        self.l2 = l2
+        self.n_bins = n_bins
+
+    # -------- core mapping --------
+    def _alpha(self, probs: torch.Tensor) -> torch.Tensor:
+        log_p = torch.log(probs.clamp_min(1e-12))
+        v = log_p - log_p.mean(dim=1, keepdim=True)
+        z = (v @ self.W.T) + self.b
+        return torch.exp(z)
+
+    def forward(self, probs: torch.Tensor) -> torch.Tensor:
+        alpha = self._alpha(probs)
+        return alpha / alpha.sum(dim=1, keepdim=True)
+
+    # -------- training on a held-out split --------
+    def fit(
+        self,
+        probs: torch.Tensor,
+        y: torch.Tensor,
+        max_iter: int = 500,
+    ) -> "DirichletCalibrator":
+        """Fit the calibrator on validation probabilities."""
+
+        y_onehot = torch.zeros_like(probs).scatter_(1, y[:, None], 1)
+
+        opt = torch.optim.LBFGS(self.parameters(), lr=0.1, max_iter=max_iter)
+
+        def closure() -> torch.Tensor:
+            opt.zero_grad()
+            alpha = self._alpha(probs)
+            S = alpha.sum(dim=1, keepdim=True)
+            nll = -(y_onehot * (digamma(alpha) - digamma(S))).sum(dim=1).mean()
+            reg = self.l2 * (self.W ** 2).mean()
+            loss = nll + reg
+            loss.backward()
+            return loss
+
+        opt.step(closure)
+        return self

--- a/src/outdist/configs/__init__.py
+++ b/src/outdist/configs/__init__.py
@@ -2,5 +2,12 @@ from .base import BaseConfig
 from .model import ModelConfig
 from .trainer import TrainerConfig
 from .data import DataConfig
+from .calibration import CalibratorConfig
 
-__all__ = ["BaseConfig", "ModelConfig", "TrainerConfig", "DataConfig"]
+__all__ = [
+    "BaseConfig",
+    "ModelConfig",
+    "TrainerConfig",
+    "DataConfig",
+    "CalibratorConfig",
+]

--- a/src/outdist/configs/calibration.py
+++ b/src/outdist/configs/calibration.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+from .base import BaseConfig
+
+__all__ = ["CalibratorConfig"]
+
+
+@dataclass
+class CalibratorConfig(BaseConfig):
+    """Configuration for calibrators."""
+
+    name: str
+    params: Dict[str, Any] = field(default_factory=dict)
+
+    def as_kwargs(self) -> Dict[str, Any]:
+        """Return stored parameters as kwargs for the calibrator constructor."""
+
+        return dict(self.params)

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,48 @@
+import torch
+from outdist.calibration import register_calibrator, get_calibrator, BaseCalibrator
+from outdist.configs.calibration import CalibratorConfig
+from outdist.training.trainer import Trainer
+from outdist.configs.trainer import TrainerConfig
+from outdist.data.datasets import make_dataset
+from outdist.data.binning import EqualWidthBinning
+from outdist.models import get_model
+
+
+@register_calibrator("dummy")
+class DummyCalibrator(BaseCalibrator):
+    def __init__(self, factor: float = 1.0, n_bins: int = 1) -> None:
+        super().__init__()
+        self.factor = factor
+        self.n_bins = n_bins
+        self.fit_called = False
+        self.forward_called = False
+
+    def forward(self, probs: torch.Tensor) -> torch.Tensor:
+        self.forward_called = True
+        return probs * self.factor
+
+    def fit(self, probs: torch.Tensor, y: torch.Tensor) -> "DummyCalibrator":
+        self.fit_called = True
+        return self
+
+
+def test_get_calibrator_instantiates_registered_calibrator():
+    cfg = CalibratorConfig(name="dummy", params={"factor": 0.5, "n_bins": 1})
+    calib = get_calibrator(cfg)
+    assert isinstance(calib, DummyCalibrator)
+    assert calib.factor == 0.5
+
+
+def test_trainer_fits_and_uses_calibrator():
+    train_ds, val_ds, test_ds = make_dataset("dummy", n_samples=20)
+    binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
+    calib_cfg = CalibratorConfig(name="dummy", params={"factor": 1.0})
+    trainer = Trainer(TrainerConfig(max_epochs=1, batch_size=4), calibrator_cfg=calib_cfg)
+    model = get_model("mlp", in_dim=1, out_dim=10, hidden_dims=[4])
+    ckpt = trainer.fit(model, binning, train_ds, val_ds)
+    assert isinstance(trainer.calibrator, DummyCalibrator)
+    assert trainer.calibrator.fit_called
+
+    results = trainer.evaluate(ckpt.model, test_ds, metrics=["nll"])
+    assert "nll" in results
+    assert trainer.calibrator.forward_called


### PR DESCRIPTION
## Summary
- add generic calibration registry and config
- implement `DirichletCalibrator`
- update `Trainer` to handle calibrators and fit them on validation data
- expose calibration options in training CLI
- include unit tests for calibration utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871fd110e408324aeafc0dc8413fbcf