### PR TITLE
Add tree-based LinCDE and RFCDE models

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The following model names can be passed to `get_model` or the CLI:
 - `logistic_mixture` – mixture of logistics
 - `ckde` – conditional kernel density estimator
 - `quantile_rf` – quantile regression forest
+- `lincde` – tree-based estimator via Lindsey's method
+- `rfcde` – random forest conditional density estimator
 - `evidential` – placeholder for an evidential neural network
 
 Additional architectures can register themselves via

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ torch
 numpy
 scikit-learn
 nflows
+rfcde

--- a/src/outdist/models/__init__.py
+++ b/src/outdist/models/__init__.py
@@ -44,6 +44,8 @@ from . import gaussian_ls  # noqa: F401
 from . import mdn  # noqa: F401
 from . import quantile_rf  # noqa: F401
 from . import ckde  # noqa: F401
+from . import lincde  # noqa: F401
+from . import rfcde  # noqa: F401
 from . import logistic_mixture  # noqa: F401
 from . import evidential  # noqa: F401
 from . import flow_cde  # noqa: F401

--- a/src/outdist/models/lincde.py
+++ b/src/outdist/models/lincde.py
@@ -1,0 +1,86 @@
+"""LinCDE tree-based conditional density estimator."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from torch import nn
+
+from .base import BaseModel
+from ..configs.model import ModelConfig
+from . import register_model
+
+try:
+    from lincde import LinCDE  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    LinCDE = None
+
+
+@register_model("lincde")
+class LinCDEModel(BaseModel):
+    """Wrapper around :mod:`lincde` providing logits over bins."""
+
+    def __init__(
+        self,
+        in_dim: int = 1,
+        start: float = 0.0,
+        end: float = 1.0,
+        n_bins: int = 10,
+        basis: int = 31,
+        trees: int = 400,
+        lr: float = 0.05,
+        depth: int = 3,
+    ) -> None:
+        super().__init__()
+        if LinCDE is None:  # pragma: no cover - dependency not installed
+            raise ImportError("LinCDE package is required for LinCDEModel")
+        edges = torch.linspace(start, end, n_bins + 1)
+        self.register_buffer("bin_edges", edges)
+        self.y_grid = np.linspace(start, end, basis)
+        self.model = LinCDE(
+            basis="bspline",
+            n_basis=basis,
+            n_trees=trees,
+            learning_rate=lr,
+            max_depth=depth,
+        )
+
+    # ------------------------------------------------------------------
+    def fit(self, x: torch.Tensor, y: torch.Tensor) -> "LinCDEModel":
+        self.model.fit(x.detach().cpu().numpy(), y.detach().cpu().numpy())
+        return self
+
+    # ------------------------------------------------------------------
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if not hasattr(self.model, "trees_"):
+            raise RuntimeError("Model must be fitted before calling forward")
+        logf = torch.from_numpy(
+            self.model.predict_log_density(x.detach().cpu().numpy())
+        ).to(x.device)
+        density = logf.exp()
+        cdf_basis = torch.cumsum(density, dim=1)
+        idx = torch.bucketize(
+            self.bin_edges.detach().cpu(),
+            torch.from_numpy(self.model.y_grid_),
+        )
+        cdf_edges = cdf_basis[:, idx]
+        probs = cdf_edges[:, 1:] - cdf_edges[:, :-1]
+        eps = torch.finfo(probs.dtype).tiny
+        return torch.log(probs.clamp_min(eps))
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def default_config(cls) -> ModelConfig:
+        return ModelConfig(
+            name="lincde",
+            params={
+                "in_dim": 1,
+                "start": 0.0,
+                "end": 1.0,
+                "n_bins": 10,
+                "basis": 31,
+                "trees": 400,
+                "lr": 0.05,
+                "depth": 3,
+            },
+        )

--- a/src/outdist/models/rfcde.py
+++ b/src/outdist/models/rfcde.py
@@ -1,0 +1,81 @@
+"""RFCDE random-forest conditional density estimator."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from torch import nn
+
+from .base import BaseModel
+from ..configs.model import ModelConfig
+from . import register_model
+
+try:
+    from rfcde import RFCDE  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    RFCDE = None
+
+
+@register_model("rfcde")
+class RFCDEModel(BaseModel):
+    """Wrapper around :mod:`rfcde` returning logits over bins."""
+
+    def __init__(
+        self,
+        in_dim: int = 1,
+        start: float = 0.0,
+        end: float = 1.0,
+        n_bins: int = 10,
+        bandwidth: float = 0.2,
+        trees: int = 500,
+        kde_basis: int = 31,
+        min_leaf: int = 5,
+    ) -> None:
+        super().__init__()
+        if RFCDE is None:  # pragma: no cover - dependency not installed
+            raise ImportError("RFCDE package is required for RFCDEModel")
+        self.bandwidth = bandwidth
+        self.model = RFCDE(
+            n_trees=trees,
+            mtry=in_dim,
+            node_size=min_leaf,
+            n_basis=kde_basis,
+        )
+        edges = torch.linspace(start, end, n_bins + 1)
+        self.register_buffer("bin_edges", edges)
+
+    # ------------------------------------------------------------------
+    def fit(self, x: torch.Tensor, y: torch.Tensor) -> "RFCDEModel":
+        self.model.train(x.detach().cpu().double().numpy(), y.detach().cpu().double().numpy())
+        return self
+
+    # ------------------------------------------------------------------
+    @torch.no_grad()
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if getattr(self.model, "z_train", None) is None:
+            raise RuntimeError("Model must be fitted before calling forward")
+        x_np = x.detach().cpu().double().numpy()
+        grid = self.bin_edges.cpu().double().numpy()
+        pdf = self.model.predict(x_np, grid, bandwidth=self.bandwidth)
+        diff = np.diff(grid)
+        cdf = np.concatenate([np.zeros((pdf.shape[0], 1)), np.cumsum(0.5 * (pdf[:, :-1] + pdf[:, 1:]) * diff, axis=1)], axis=1)
+        probs = torch.from_numpy(cdf[:, 1:] - cdf[:, :-1]).to(x.device)
+        eps = torch.finfo(probs.dtype).tiny
+        return torch.log(probs.clamp_min(eps))
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def default_config(cls) -> ModelConfig:
+        return ModelConfig(
+            name="rfcde",
+            params={
+                "in_dim": 1,
+                "start": 0.0,
+                "end": 1.0,
+                "n_bins": 10,
+                "bandwidth": 0.2,
+                "trees": 500,
+                "kde_basis": 31,
+                "min_leaf": 5,
+            },
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,10 @@ def test_train_cli_runs(tmp_path, monkeypatch):
     train.main(args)
 
 
-@pytest.mark.parametrize("name", MODEL_REGISTRY.keys())
+@pytest.mark.parametrize(
+    "name",
+    [n for n in MODEL_REGISTRY.keys() if n not in {"lincde", "rfcde"}],
+)
 def test_train_cli_registered_models(name, tmp_path, monkeypatch):
     args = ["--model", name, "--dataset", "dummy", "--epochs", "0", "--batch-size", "2"]
     monkeypatch.chdir(tmp_path)
@@ -41,7 +44,11 @@ def test_evaluate_cli_runs(tmp_path, monkeypatch):
 
 @pytest.mark.parametrize(
     "name",
-    [n for n in MODEL_REGISTRY.keys() if n not in {"ckde", "quantile_rf"}],
+    [
+        n
+        for n in MODEL_REGISTRY.keys()
+        if n not in {"ckde", "quantile_rf", "lincde", "rfcde"}
+    ],
 )
 def test_evaluate_cli_registered_models(name, tmp_path, monkeypatch):
     args = [

--- a/tests/test_lincde_model.py
+++ b/tests/test_lincde_model.py
@@ -1,0 +1,30 @@
+import torch
+import pytest
+
+lincde = pytest.importorskip("lincde")
+from outdist.models import get_model
+from outdist.models.lincde import LinCDEModel
+
+
+def test_lincde_forward_shape():
+    model = get_model(
+        "lincde",
+        in_dim=1,
+        start=0.0,
+        end=1.0,
+        n_bins=5,
+        basis=6,
+        trees=10,
+    )
+    x_train = torch.randn(20, 1)
+    y_train = torch.rand(20)
+    model.fit(x_train, y_train)
+    x = torch.randn(4, 1)
+    logits = model(x)
+    assert logits.shape == (4, 5)
+
+
+def test_default_config_instantiates_lincde():
+    cfg = LinCDEModel.default_config()
+    model = get_model(cfg)
+    assert isinstance(model, LinCDEModel)

--- a/tests/test_rfcde_model.py
+++ b/tests/test_rfcde_model.py
@@ -1,0 +1,32 @@
+import torch
+import pytest
+
+rfcde = pytest.importorskip("rfcde")
+from outdist.models import get_model
+from outdist.models.rfcde import RFCDEModel
+
+
+def test_rfcde_forward_shape():
+    model = get_model(
+        "rfcde",
+        in_dim=1,
+        start=0.0,
+        end=1.0,
+        n_bins=5,
+        bandwidth=0.1,
+        trees=5,
+        kde_basis=7,
+        min_leaf=2,
+    )
+    x_train = torch.randn(20, 1)
+    y_train = torch.rand(20)
+    model.fit(x_train, y_train)
+    x = torch.randn(4, 1)
+    logits = model(x)
+    assert logits.shape == (4, 5)
+
+
+def test_default_config_instantiates_rfcde():
+    cfg = RFCDEModel.default_config()
+    model = get_model(cfg)
+    assert isinstance(model, RFCDEModel)

--- a/tests/test_trainer_models.py
+++ b/tests/test_trainer_models.py
@@ -6,6 +6,7 @@ from outdist.configs.trainer import TrainerConfig
 from outdist.data.datasets import make_dataset
 from outdist.data.binning import EqualWidthBinning
 from outdist.models import get_model
+import importlib
 
 
 MODEL_CONFIGS = [
@@ -41,6 +42,43 @@ MODEL_CONFIGS = [
             "n_estimators": 5,
             "random_state": 0,
         },
+    ),
+    # Optional models depending on extra packages
+    *(
+        [
+            (
+                "lincde",
+                {
+                    "in_dim": 1,
+                    "start": 0.0,
+                    "end": 1.0,
+                    "n_bins": 10,
+                    "basis": 6,
+                    "trees": 10,
+                },
+            )
+        ]
+        if importlib.util.find_spec("lincde")
+        else []
+    ),
+    *(
+        [
+            (
+                "rfcde",
+                {
+                    "in_dim": 1,
+                    "start": 0.0,
+                    "end": 1.0,
+                    "n_bins": 10,
+                    "bandwidth": 0.1,
+                    "trees": 5,
+                    "kde_basis": 7,
+                    "min_leaf": 2,
+                },
+            )
+        ]
+        if importlib.util.find_spec("rfcde")
+        else []
     ),
     ("evidential", {"in_dim": 1, "n_bins": 10, "hidden_dims": [4, 4]}),
     (


### PR DESCRIPTION
## Summary
- implement `LinCDEModel` and `RFCDEModel`
- register new models
- update CLI and trainer tests to account for optional dependencies
- document new models in the README
- include tests for both implementations
- add `rfcde` to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872065c3e188324958fcab32795b058