### PR TITLE
Enable learnable bins for all models

### DIFF
--- a/src/outdist/training/trainer.py
+++ b/src/outdist/training/trainer.py
@@ -64,6 +64,10 @@ class Trainer:
         if targets:
             y_all = torch.cat(targets)
             binning.fit(y_all)
+            if isinstance(binning, binning_scheme.LearnableBinningScheme) and not isinstance(model, nn.Module):
+                raise TypeError("Learnable bins require model to be an nn.Module")
+            if hasattr(model, "binner"):
+                model.binner = binning
             if hasattr(model, "fit"):
                 x_all = torch.cat(features)
                 model.fit(x_all.to(self.device), y_all.to(self.device))

--- a/tests/test_trainer_binning.py
+++ b/tests/test_trainer_binning.py
@@ -1,8 +1,9 @@
 import torch
+import pytest
 from outdist.training.trainer import Trainer
 from outdist.configs.trainer import TrainerConfig
 from outdist.data.datasets import make_dataset
-from outdist.data.binning import BinningScheme
+from outdist.data.binning import BinningScheme, LearnableBinningScheme
 from outdist.models import register_model, BaseModel
 from outdist.configs.model import ModelConfig
 
@@ -22,6 +23,7 @@ class DummyModel(BaseModel):
     def __init__(self, out_dim: int = 10):
         super().__init__()
         self.fc = torch.nn.Linear(1, out_dim)
+        self.binner = None
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.fc(x)
@@ -31,6 +33,17 @@ class DummyModel(BaseModel):
         return ModelConfig(name="trainer_dummy", params={"out_dim": 10})
 
 
+class PlainModel:
+    def to(self, device):
+        return self
+
+    def parameters(self):
+        return []
+
+    def __call__(self, x):
+        return x
+
+
 def test_trainer_fits_binning_before_training():
     train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
     trainer = Trainer(TrainerConfig(max_epochs=0))
@@ -38,3 +51,22 @@ def test_trainer_fits_binning_before_training():
     binning = DummyBinning()
     trainer.fit(model, binning, train_ds, val_ds)
     assert binning.fit_called
+
+
+def test_trainer_accepts_learnable_bins():
+    train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
+    trainer = Trainer(TrainerConfig(max_epochs=0))
+    binner = LearnableBinningScheme(5, 0.0, 1.0)
+    model = DummyModel(out_dim=5)
+    trainer.fit(model, binner, train_ds, val_ds)
+    assert isinstance(model.binner, LearnableBinningScheme)
+
+
+def test_trainer_rejects_learnable_bins_for_nonmodule():
+    train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
+    trainer = Trainer(TrainerConfig(max_epochs=0))
+    binner = LearnableBinningScheme(5, 0.0, 1.0)
+    model = PlainModel()
+    with pytest.raises(TypeError):
+        trainer.fit(model, binner, train_ds, val_ds)
+


### PR DESCRIPTION
## Summary
- allow Gaussian LS, MDN, logistic mixture, CKDE, flow and tree models to accept a learnable binning scheme
- remove the separate `flow_learnbins` implementation
- attach a learnable binner in the trainer and verify it only works for `nn.Module` models
- test trainer behaviour with learnable bins

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68720cdd56148324b9ad8b46985cfe0a