### PR TITLE
Add ensemble training and wrapper classes

### DIFF
--- a/src/outdist/__init__.py
+++ b/src/outdist/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from .models import get_model, register_model  # re-exported for convenience
 from .training.trainer import Trainer
+from .training.ensemble_trainer import EnsembleTrainer
+from .ensembles.average import AverageEnsemble
 from .data.datasets import make_dataset
 from .calibration import get_calibrator, register_calibrator
 
@@ -14,6 +16,8 @@ __all__ = [
     "get_calibrator",
     "register_calibrator",
     "Trainer",
+    "EnsembleTrainer",
+    "AverageEnsemble",
     "make_dataset",
 ]
 

--- a/src/outdist/ensembles/average.py
+++ b/src/outdist/ensembles/average.py
@@ -1,0 +1,46 @@
+import torch
+import numpy as np
+from typing import List, Any
+
+class AverageEnsemble:
+    """Probabilistic ensemble averaging per-model probabilities."""
+    def __init__(self, models: List[Any]):
+        self.models = models
+        # sanity check on n_bins if possible
+        try:
+            bins = {
+                model(torch.randn(1, getattr(model, "in_dim", 1))).shape[-1]
+                for model in models
+            }
+            if len(bins) > 1:
+                raise AssertionError("Sub-models disagree on n_bins")
+        except Exception:
+            pass
+
+    @torch.no_grad()
+    def bin_logits(self, x: torch.Tensor) -> torch.Tensor:
+        probs = torch.stack([model(x).softmax(dim=-1) for model in self.models])
+        mean_probs = probs.mean(0)
+        return (mean_probs + 1e-12).log()
+
+    @torch.no_grad()
+    def log_prob(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        lp = torch.stack([
+            torch.log_softmax(model(x), dim=-1).gather(-1, y.unsqueeze(-1)).squeeze(-1)
+            for model in self.models
+        ])
+        return torch.logsumexp(lp, dim=0) - np.log(len(self.models))
+
+    def sample(self, x: torch.Tensor, n: int = 100) -> torch.Tensor:
+        idx = torch.randint(0, len(self.models), (n,))
+        samples = []
+        for i in idx:
+            model = self.models[i]
+            if hasattr(model, "sample"):
+                samples.append(model.sample(x, 1)[0])
+            else:
+                # fallback: categorical sampling from predicted probabilities
+                probs = torch.softmax(model(x), dim=-1)
+                dist = torch.distributions.Categorical(probs=probs)
+                samples.append(dist.sample().float())
+        return torch.stack(samples)

--- a/src/outdist/training/ensemble_trainer.py
+++ b/src/outdist/training/ensemble_trainer.py
@@ -1,0 +1,82 @@
+import copy
+import random
+import numpy as np
+import torch
+from typing import Any, List, Tuple, Optional
+
+from joblib import Parallel, delayed
+
+from ..models import get_model
+from ..configs.trainer import TrainerConfig
+from ..configs.model import ModelConfig
+from ..data.binning import BinningScheme
+from .trainer import Trainer
+from ..ensembles.average import AverageEnsemble
+
+class EnsembleTrainer:
+    """Bagging / deep ensemble trainer."""
+
+    def __init__(
+        self,
+        model_cfgs: List[ModelConfig | str | dict],
+        trainer_cfg: TrainerConfig,
+        *,
+        seed: int = 0,
+        bootstrap: bool = True,
+        n_jobs: int = 1,
+        device: str | None = None,
+    ) -> None:
+        self.model_cfgs = model_cfgs
+        self.trainer_cfg = trainer_cfg
+        self.seed = seed
+        self.bootstrap = bootstrap
+        self.n_jobs = n_jobs
+        self.device = device or trainer_cfg.device
+
+    # ------------------------------------------------------------------
+    def _fit_one(
+        self,
+        cfg_idx: int,
+        binning: BinningScheme,
+        data: Tuple[torch.utils.data.Dataset, Optional[torch.utils.data.Dataset]],
+    ):
+        train_ds, val_ds = data
+        cfg = copy.deepcopy(self.model_cfgs[cfg_idx])
+        torch.manual_seed(self.seed + cfg_idx)
+        np.random.seed(self.seed + cfg_idx)
+        random.seed(self.seed + cfg_idx)
+
+        if isinstance(cfg, str):
+            model = get_model(ModelConfig(name=cfg))
+        elif isinstance(cfg, dict) and "name" in cfg:
+            model = get_model(ModelConfig(**cfg))
+        else:
+            model = get_model(cfg)  # type: ignore[arg-type]
+
+        if self.bootstrap:
+            idx = torch.randint(0, len(train_ds), (len(train_ds),))
+            subset = torch.utils.data.Subset(train_ds, idx.tolist())
+        else:
+            subset = train_ds
+
+        tr_cfg = copy.deepcopy(self.trainer_cfg)
+        tr_cfg.device = self.device
+        trainer = Trainer(tr_cfg)
+        ckpt = trainer.fit(model, binning, subset, val_ds)
+        return ckpt.model
+
+    # ------------------------------------------------------------------
+    def fit(
+        self,
+        binning: BinningScheme,
+        train_ds: torch.utils.data.Dataset,
+        val_ds: Optional[torch.utils.data.Dataset] = None,
+    ) -> AverageEnsemble:
+        data = (train_ds, val_ds)
+        if self.n_jobs == 1:
+            models = [self._fit_one(i, binning, data) for i in range(len(self.model_cfgs))]
+        else:
+            models = Parallel(n_jobs=self.n_jobs)(
+                delayed(self._fit_one)(i, binning, data) for i in range(len(self.model_cfgs))
+            )
+        return AverageEnsemble(models)


### PR DESCRIPTION
## Summary
- implement `AverageEnsemble` for probability averaging
- add `EnsembleTrainer` to orchestrate multiple model trainings
- expose new classes from package root

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872261976648324b30bf3e17bf1fdb4