### PR TITLE
Add conformal predictor support

### DIFF
--- a/src/outdist/conformal/__init__.py
+++ b/src/outdist/conformal/__init__.py
@@ -1,0 +1,4 @@
+from .base import BaseConformal
+from .chcds import CHCDSConformal
+
+__all__ = ["BaseConformal", "CHCDSConformal"]

--- a/src/outdist/conformal/base.py
+++ b/src/outdist/conformal/base.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+# ------------------------------------------
+from abc import ABC, abstractmethod
+import torch
+
+class BaseConformal(ABC):
+    """Set-valued conformal predictor wrapping a probabilistic base model."""
+
+    def __init__(self, base):
+        self.base = base
+
+    @abstractmethod
+    def calibrate(self, X_cal, y_cal, alpha: float):
+        """Fit the conformal adapter on calibration data."""
+        ...
+
+    @abstractmethod
+    @torch.no_grad()
+    def contains(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """Return a boolean mask indicating set membership."""
+        ...
+
+    # ------------------------------------------------------------------
+    def coverage(self, x: torch.Tensor, y: torch.Tensor) -> float:
+        """Return empirical coverage on ``(x, y)``."""
+        return self.contains(x, y).float().mean().item()

--- a/src/outdist/conformal/chcds.py
+++ b/src/outdist/conformal/chcds.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+# ------------------------------------------
+import torch
+import numpy as np
+
+from .base import BaseConformal
+
+
+class CHCDSConformal(BaseConformal):
+    """Conformal Highest Conditional Density Sets."""
+
+    def __init__(self, base, tau: float = 0.90, mode: str = "sub", eps: float = 1e-12) -> None:
+        super().__init__(base)
+        assert mode in {"sub", "div"}
+        self.tau = tau
+        self.mode = mode
+        self.eps = eps
+        self.delta: float | None = None
+
+    # ------------------------------------------------------------------
+    @torch.no_grad()
+    def _hd_cutoff(self, x: torch.Tensor) -> torch.Tensor:
+        logits = self.base.bin_logits(x)
+        probs = logits.exp()
+        widths = self.base.bins.edges[1:] - self.base.bins.edges[:-1]
+        rho = probs / widths
+
+        sort_idx = torch.argsort(rho, dim=1, descending=True)
+        rho_s = torch.gather(rho, 1, sort_idx)
+        prob_s = torch.gather(probs, 1, sort_idx)
+        cum_mass = prob_s.cumsum(dim=1)
+        k_star = (cum_mass < self.tau).sum(dim=1).clamp(max=rho.size(1) - 1)
+        rows = torch.arange(x.size(0), device=x.device)
+        return rho_s[rows, k_star]
+
+    # ------------------------------------------------------------------
+    @torch.no_grad()
+    def calibrate(self, X_cal, y_cal, alpha: float):
+        x = torch.as_tensor(X_cal, dtype=torch.float32)
+        y = torch.as_tensor(y_cal, dtype=torch.float32)
+        c_hd = self._hd_cutoff(x)
+        dens = self.base.log_prob(x, y).exp()
+        if self.mode == "sub":
+            scores = c_hd - dens
+        else:
+            scores = c_hd / (dens + self.eps)
+        m = len(scores)
+        q = torch.quantile(
+            scores,
+            (1 - alpha) * (m + 1) / m,
+            interpolation="higher",
+        )
+        self.delta = q.item()
+        return self
+
+    # ------------------------------------------------------------------
+    @torch.no_grad()
+    def _cutoff(self, x: torch.Tensor) -> torch.Tensor:
+        base = self._hd_cutoff(x)
+        if self.mode == "sub":
+            return (base - self.delta).clamp(min=0.0)
+        return base / max(self.delta, self.eps)
+
+    # ------------------------------------------------------------------
+    @torch.no_grad()
+    def contains(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        dens = self.base.log_prob(x, y).exp()
+        return dens >= self._cutoff(x)

--- a/tests/test_conformal.py
+++ b/tests/test_conformal.py
@@ -1,0 +1,51 @@
+import torch
+from torch.utils.data import TensorDataset
+
+from outdist.conformal.chcds import CHCDSConformal
+from outdist.training.trainer import Trainer
+from outdist.configs.trainer import TrainerConfig
+from outdist.data.binning import EqualWidthBinning
+
+
+class DummyBaseModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        class Bins:
+            edges = torch.tensor([0.0, 1.0, 2.0])
+        self.bins = Bins()
+
+    @torch.no_grad()
+    def bin_logits(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.zeros(x.size(0), 2)
+
+    @torch.no_grad()
+    def log_prob(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return torch.full_like(y, torch.log(torch.tensor(0.5)))
+
+
+def test_chcds_conformal_basic():
+    base = DummyBaseModel()
+    adapter = CHCDSConformal(base)
+    x = torch.randn(20, 1)
+    y = torch.rand(20)
+    adapter.calibrate(x, y, alpha=0.1)
+    assert adapter.delta is not None
+    mask = adapter.contains(x, y)
+    assert mask.dtype == torch.bool
+    cov = adapter.coverage(x, y)
+    assert isinstance(cov, float)
+
+
+def test_trainer_applies_conformal():
+    train_x = torch.randn(20, 1)
+    train_y = torch.rand(20)
+    val_x = torch.randn(10, 1)
+    val_y = torch.rand(10)
+    train_ds = TensorDataset(train_x, train_y)
+    val_ds = TensorDataset(val_x, val_y)
+    binning = EqualWidthBinning(0.0, 2.0, n_bins=2)
+    model = DummyBaseModel()
+    trainer = Trainer(TrainerConfig(max_epochs=0))
+    ckpt = trainer.fit(model, binning, train_ds, val_ds, conformal_cfg={"alpha": 0.1})
+    assert isinstance(ckpt.model, CHCDSConformal)
+    assert ckpt.model.delta is not None


### PR DESCRIPTION
## Summary
- implement BaseConformal and CHCDSConformal classes
- update Trainer to optionally fit conformal adapter
- test new conformal modules and integration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68722d9fc4e48324a891b142919a7497