### PR TITLE
Remove deprecated bootstrapped binning

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ Implemented strategies include:
 
 - `EqualWidthBinning` – evenly spaced edges between a start and end value
 - `QuantileBinning` – edges based on quantiles of observed data
-- `BootstrappedUniformBinning` – average uniform bins over bootstrap samples
-- `BootstrappedQuantileBinning` – average quantile bins over bootstrap samples
 
 ## Calibration
 

--- a/src/outdist/training/ensemble_trainer.py
+++ b/src/outdist/training/ensemble_trainer.py
@@ -9,7 +9,7 @@ from joblib import Parallel, delayed
 from ..models import get_model
 from ..configs.trainer import TrainerConfig
 from ..configs.model import ModelConfig
-from ..data.binning import BinningScheme
+from ..data.binning import BinningScheme, LearnableBinningScheme
 from .trainer import Trainer
 from ..ensembles.average import AverageEnsemble
 from ..ensembles.stacked import StackedEnsemble, learn_weights
@@ -80,6 +80,8 @@ class EnsembleTrainer:
         val_ds: Optional[torch.utils.data.Dataset] = None,
     ) -> AverageEnsemble:
         data = (train_ds, val_ds)
+        if self.bootstrap and isinstance(binning, LearnableBinningScheme):
+            raise ValueError("Bootstrapping is incompatible with LearnableBinningScheme")
         if self.n_jobs == 1:
             models = [self._fit_one(i, binning, data) for i in range(len(self.model_cfgs))]
         else:


### PR DESCRIPTION
## Summary
- drop `Bootstrapped*` binning schemes and their docs/tests
- prohibit `LearnableBinningScheme` with bootstrapping in `EnsembleTrainer`
- adjust tests for updated behaviour

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ec038d0083248efbcd8386363d1e