### PR TITLE
Add training logger

### DIFF
--- a/src/outdist/__init__.py
+++ b/src/outdist/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .models import get_model, register_model  # re-exported for convenience
 from .training.trainer import Trainer
 from .training.ensemble_trainer import EnsembleTrainer
+from .training.logger import TrainingLogger, ConsoleLogger
 from .ensembles.average import AverageEnsemble
 from .ensembles.stacked import StackedEnsemble
 from .data.datasets import make_dataset
@@ -18,6 +19,8 @@ __all__ = [
     "register_calibrator",
     "Trainer",
     "EnsembleTrainer",
+    "TrainingLogger",
+    "ConsoleLogger",
     "AverageEnsemble",
     "StackedEnsemble",
     "make_dataset",

--- a/src/outdist/training/ensemble_trainer.py
+++ b/src/outdist/training/ensemble_trainer.py
@@ -11,6 +11,7 @@ from ..configs.trainer import TrainerConfig
 from ..configs.model import ModelConfig
 from ..data.binning import BinningScheme, LearnableBinningScheme
 from .trainer import Trainer
+from .logger import TrainingLogger
 from ..ensembles.average import AverageEnsemble
 from ..ensembles.stacked import StackedEnsemble, learn_weights
 from ..data import binning as binning_scheme
@@ -80,6 +81,7 @@ class EnsembleTrainer:
         device: str | None = None,
         stack: bool = False,
         stack_cfg: dict | None = None,
+        logger: TrainingLogger | None = None,
     ) -> None:
         self.model_cfgs = model_cfgs
         self.trainer_cfg = trainer_cfg
@@ -89,6 +91,7 @@ class EnsembleTrainer:
         self.device = device or trainer_cfg.device
         self.stack = stack
         self.stack_cfg = stack_cfg or {}
+        self.logger = logger
 
     # ------------------------------------------------------------------
     def _align_binning(self, models: List[Any]) -> List[Any]:
@@ -149,7 +152,7 @@ class EnsembleTrainer:
 
         tr_cfg = copy.deepcopy(self.trainer_cfg)
         tr_cfg.device = self.device
-        trainer = Trainer(tr_cfg)
+        trainer = Trainer(tr_cfg, logger=self.logger)
         ckpt = trainer.fit(model, binning, subset, val_ds)
         return ckpt.model
 

--- a/src/outdist/training/logger.py
+++ b/src/outdist/training/logger.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import List
+
+
+class TrainingLogger:
+    """Base class for tracking training progress."""
+
+    def __init__(self) -> None:
+        self.losses: List[float] = []
+        self.num_batches: int = 0
+
+    # ------------------------------------------------------------------
+    def start_epoch(self, epoch: int, num_batches: int) -> None:
+        """Reset state for a new epoch."""
+        self.losses = []
+        self.num_batches = num_batches
+
+    # ------------------------------------------------------------------
+    def log_batch(self, batch_idx: int, loss: float) -> None:
+        """Record statistics for a finished batch."""
+        self.losses.append(loss)
+        self.on_batch_end(batch_idx, loss)
+
+    # ------------------------------------------------------------------
+    def end_epoch(self, epoch: int) -> None:
+        """Compute epoch statistics and trigger :meth:`on_epoch_end`."""
+        avg = sum(self.losses) / len(self.losses) if self.losses else 0.0
+        self.on_epoch_end(epoch, avg)
+
+    # ------------------------------------------------------------------
+    def on_batch_end(self, batch_idx: int, loss: float) -> None:  # pragma: no cover - hook
+        """Hook executed when a batch finishes."""
+        pass
+
+    # ------------------------------------------------------------------
+    def on_epoch_end(self, epoch: int, avg_loss: float) -> None:  # pragma: no cover - hook
+        """Hook executed at the end of an epoch."""
+        pass
+
+
+class ConsoleLogger(TrainingLogger):
+    """Simple logger that prints batch and epoch statistics to ``stdout``."""
+
+    def on_batch_end(self, batch_idx: int, loss: float) -> None:
+        print(f"Batch {batch_idx + 1}/{self.num_batches} loss: {loss:.4f}")
+
+    def on_epoch_end(self, epoch: int, avg_loss: float) -> None:
+        print(f"Epoch {epoch} average loss: {avg_loss:.4f}")
+

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,41 @@
+import math
+
+from outdist.training.logger import TrainingLogger, ConsoleLogger
+from outdist.training.trainer import Trainer
+from outdist.configs.trainer import TrainerConfig
+from outdist.data.datasets import make_dataset
+from outdist.data.binning import EqualWidthBinning
+from outdist.models import get_model
+
+
+class CountingLogger(TrainingLogger):
+    def __init__(self) -> None:
+        super().__init__()
+        self.batches = 0
+        self.epochs = 0
+        self.avgs = []
+
+    def on_batch_end(self, batch_idx: int, loss: float) -> None:
+        self.batches += 1
+
+    def on_epoch_end(self, epoch: int, avg_loss: float) -> None:
+        self.epochs += 1
+        self.avgs.append(avg_loss)
+
+
+def test_trainer_uses_logger() -> None:
+    train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
+    logger = CountingLogger()
+    trainer = Trainer(TrainerConfig(max_epochs=1, batch_size=4), logger=logger)
+    binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
+    model = get_model("logreg", in_dim=1, out_dim=10)
+    trainer.fit(model, binning, train_ds, val_ds)
+
+    expected_batches = math.ceil(len(train_ds) / trainer.cfg.batch_size)
+    assert logger.batches == expected_batches
+    assert logger.epochs == 1
+    assert logger.avgs
+
+
+def test_console_logger_subclass() -> None:
+    assert issubclass(ConsoleLogger, TrainingLogger)


### PR DESCRIPTION
## Summary
- introduce `TrainingLogger` base class and `ConsoleLogger`
- allow `Trainer` and `EnsembleTrainer` to accept an optional logger
- expose the new logger classes in the package API
- test that trainer interacts with a logger

## Testing
- `pip install -q -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872f2af2b64832489853abf6195dbbe