### PR TITLE
Standardise model dimension arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ from outdist.configs.trainer import TrainerConfig
 from outdist.data.binning import EqualWidthBinning
 
 train_ds, val_ds, test_ds = make_dataset("dummy", n_samples=200)
-model = get_model("mlp", in_dim=1, out_dim=10)
+model = get_model("mlp", in_dim=1, n_bins=10)
 binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
 
 trainer = Trainer(TrainerConfig(max_epochs=5, batch_size=32))
@@ -107,8 +107,8 @@ from outdist.training.ensemble_trainer import EnsembleTrainer
 from outdist.configs.model import ModelConfig
 
 model_cfgs = [
-    ModelConfig(name="mlp", params={"in_dim": 1, "out_dim": 10, "hidden_dims": [4]}),
-    ModelConfig(name="logreg", params={"in_dim": 1, "out_dim": 10}),
+    ModelConfig(name="mlp", params={"in_dim": 1, "n_bins": 10, "hidden_dims": [4]}),
+    ModelConfig(name="logreg", params={"in_dim": 1, "n_bins": 10}),
 ]
 ens_trainer = EnsembleTrainer(model_cfgs, TrainerConfig(max_epochs=5))
 ensemble = ens_trainer.fit(binning, train_ds, val_ds)

--- a/src/outdist/models/logistic_regression.py
+++ b/src/outdist/models/logistic_regression.py
@@ -14,13 +14,13 @@ from . import register_model
 class LogisticRegression(BaseModel):
     """Linear model mapping ``x`` to logits over discretised outcomes."""
 
-    def __init__(self, in_dim: int = 1, out_dim: int = 10) -> None:
+    def __init__(self, in_dim: int = 1, n_bins: int = 10) -> None:
         super().__init__()
-        self.linear = nn.Linear(in_dim, out_dim)
+        self.linear = nn.Linear(in_dim, n_bins)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.linear(x)
 
     @classmethod
     def default_config(cls) -> ModelConfig:
-        return ModelConfig(name="logreg", params={"in_dim": 1, "out_dim": 10})
+        return ModelConfig(name="logreg", params={"in_dim": 1, "n_bins": 10})

--- a/src/outdist/models/mlp.py
+++ b/src/outdist/models/mlp.py
@@ -20,11 +20,11 @@ class MLP(BaseModel):
     def __init__(
         self,
         in_dim: int = 1,
-        out_dim: int = 10,
+        n_bins: int = 10,
         hidden_dims: int | Sequence[int] = (32, 32),
     ) -> None:
         super().__init__()
-        self.net = make_mlp(in_dim, out_dim, hidden_dims)
+        self.net = make_mlp(in_dim, n_bins, hidden_dims)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.net(x)
@@ -32,7 +32,7 @@ class MLP(BaseModel):
     @classmethod
     def default_config(cls) -> ModelConfig:
         return ModelConfig(
-            name="mlp", params={"in_dim": 1, "out_dim": 10, "hidden_dims": [32, 32]}
+            name="mlp", params={"in_dim": 1, "n_bins": 10, "hidden_dims": [32, 32]}
         )
 
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -38,7 +38,7 @@ def test_trainer_fits_and_uses_calibrator():
     binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
     calib_cfg = CalibratorConfig(name="dummy", params={"factor": 1.0})
     trainer = Trainer(TrainerConfig(max_epochs=1, batch_size=4), calibrator_cfg=calib_cfg)
-    model = get_model("mlp", in_dim=1, out_dim=10, hidden_dims=[4])
+    model = get_model("mlp", in_dim=1, n_bins=10, hidden_dims=[4])
     ckpt = trainer.fit(model, binning, train_ds, val_ds)
     assert isinstance(trainer.calibrator, DummyCalibrator)
     assert trainer.calibrator.fit_called

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,16 +7,16 @@ from outdist.configs.model import ModelConfig
 
 @register_model("dummy_cli")
 class DummyModel(BaseModel):
-    def __init__(self, out_dim: int = 10):
+    def __init__(self, n_bins: int = 10):
         super().__init__()
-        self.fc = torch.nn.Linear(1, out_dim)
+        self.fc = torch.nn.Linear(1, n_bins)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.fc(x)
 
     @classmethod
     def default_config(cls) -> ModelConfig:
-        return ModelConfig(name="dummy_cli", params={"out_dim": 10})
+        return ModelConfig(name="dummy_cli", params={"n_bins": 10})
 
 
 def test_train_cli_runs(tmp_path, monkeypatch):

--- a/tests/test_ensemble_trainer.py
+++ b/tests/test_ensemble_trainer.py
@@ -14,8 +14,8 @@ from outdist.ensembles.average import AverageEnsemble
 
 # Same set of model configs used in trainer tests
 MODEL_CONFIGS = [
-    ("mlp", {"in_dim": 1, "out_dim": 10, "hidden_dims": [4]}),
-    ("logreg", {"in_dim": 1, "out_dim": 10}),
+    ("mlp", {"in_dim": 1, "n_bins": 10, "hidden_dims": [4]}),
+    ("logreg", {"in_dim": 1, "n_bins": 10}),
     ("gaussian_ls", {"in_dim": 1, "start": 0.0, "end": 1.0, "n_bins": 10}),
     (
         "mdn",
@@ -140,9 +140,9 @@ def test_ensemble_trainer_runs(cfg_pair) -> None:
 def test_stacked_ensemble_trainer_runs() -> None:
     model_cfgs = [
         ModelConfig(
-            name="mlp", params={"in_dim": 1, "out_dim": 10, "hidden_dims": [4]}
+            name="mlp", params={"in_dim": 1, "n_bins": 10, "hidden_dims": [4]}
         ),
-        ModelConfig(name="logreg", params={"in_dim": 1, "out_dim": 10}),
+        ModelConfig(name="logreg", params={"in_dim": 1, "n_bins": 10}),
     ]
     train_ds, val_ds, _ = make_dataset("dummy", n_samples=20)
     binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
@@ -160,7 +160,7 @@ def test_stacked_ensemble_trainer_runs() -> None:
 
 def test_ensemble_trainer_rejects_bootstrap_with_learnable_bins() -> None:
     model_cfgs = [
-        ModelConfig(name="mlp", params={"in_dim": 1, "out_dim": 10, "hidden_dims": [4]})
+        ModelConfig(name="mlp", params={"in_dim": 1, "n_bins": 10, "hidden_dims": [4]})
     ]
     train_ds, val_ds, _ = make_dataset("dummy", n_samples=20)
     binning = LearnableBinningScheme(5, 0.0, 1.0)

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -6,23 +6,23 @@ from outdist.data.datasets import make_dataset
 
 @register_model("dummy_eval")
 class DummyModel(BaseModel):
-    def __init__(self, out_dim: int = 10):
+    def __init__(self, n_bins: int = 10):
         super().__init__()
-        self.fc = torch.nn.Linear(1, out_dim)
+        self.fc = torch.nn.Linear(1, n_bins)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.fc(x)
 
     @classmethod
     def default_config(cls) -> ModelConfig:
-        return ModelConfig(name="dummy_eval", params={"out_dim": 10})
+        return ModelConfig(name="dummy_eval", params={"n_bins": 10})
 
 
 def test_cross_validate_runs():
     dataset, _, _ = make_dataset("dummy", n_samples=20)
 
     def model_factory():
-        return DummyModel(out_dim=10)
+        return DummyModel(n_bins=10)
 
     results = cross_validate(model_factory, dataset, k_folds=2, metrics=["nll"], trainer_cfg=None)
     assert len(results) == 2

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -28,7 +28,7 @@ def test_trainer_uses_logger() -> None:
     logger = CountingLogger()
     trainer = Trainer(TrainerConfig(max_epochs=1, batch_size=4), logger=logger)
     binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
-    model = get_model("logreg", in_dim=1, out_dim=10)
+    model = get_model("logreg", in_dim=1, n_bins=10)
     trainer.fit(model, binning, train_ds, val_ds)
 
     expected_batches = math.ceil(len(train_ds) / trainer.cfg.batch_size)

--- a/tests/test_logistic_regression_model.py
+++ b/tests/test_logistic_regression_model.py
@@ -4,7 +4,7 @@ from outdist.models.logistic_regression import LogisticRegression
 
 
 def test_logreg_forward_shape():
-    model = get_model("logreg", in_dim=3, out_dim=4)
+    model = get_model("logreg", in_dim=3, n_bins=4)
     x = torch.randn(2, 3)
     logits = model(x)
     assert logits.shape == (2, 4)

--- a/tests/test_mlp_model.py
+++ b/tests/test_mlp_model.py
@@ -4,7 +4,7 @@ from outdist.models.mlp import MLP
 
 
 def test_mlp_forward_shape():
-    model = get_model("mlp", in_dim=2, out_dim=3, hidden_dims=[4])
+    model = get_model("mlp", in_dim=2, n_bins=3, hidden_dims=[4])
     x = torch.randn(5, 2)
     logits = model(x)
     assert logits.shape == (5, 3)

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -4,20 +4,20 @@ from outdist.configs.model import ModelConfig
 
 @register_model("dummy")
 class DummyModel(BaseModel):
-    def __init__(self, out_dim: int = 1):
+    def __init__(self, n_bins: int = 1):
         super().__init__()
-        self.fc = torch.nn.Linear(1, out_dim)
+        self.fc = torch.nn.Linear(1, n_bins)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.fc(x)
 
     @classmethod
     def default_config(cls) -> ModelConfig:
-        return ModelConfig(name="dummy", params={"out_dim": 1})
+        return ModelConfig(name="dummy", params={"n_bins": 1})
 
 
 def test_get_model_instantiates_registered_model():
-    cfg = ModelConfig(name="dummy", params={"out_dim": 2})
+    cfg = ModelConfig(name="dummy", params={"n_bins": 2})
     model = get_model(cfg)
     assert isinstance(model, DummyModel)
     assert model.fc.out_features == 2

--- a/tests/test_trainer_binning.py
+++ b/tests/test_trainer_binning.py
@@ -20,9 +20,9 @@ class DummyBinning(BinningScheme):
 
 @register_model("trainer_dummy")
 class DummyModel(BaseModel):
-    def __init__(self, out_dim: int = 10):
+    def __init__(self, n_bins: int = 10):
         super().__init__()
-        self.fc = torch.nn.Linear(1, out_dim)
+        self.fc = torch.nn.Linear(1, n_bins)
         self.binner = None
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -30,7 +30,7 @@ class DummyModel(BaseModel):
 
     @classmethod
     def default_config(cls) -> ModelConfig:
-        return ModelConfig(name="trainer_dummy", params={"out_dim": 10})
+        return ModelConfig(name="trainer_dummy", params={"n_bins": 10})
 
 
 class PlainModel:
@@ -47,7 +47,7 @@ class PlainModel:
 def test_trainer_fits_binning_before_training():
     train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
     trainer = Trainer(TrainerConfig(max_epochs=0))
-    model = DummyModel(out_dim=10)
+    model = DummyModel(n_bins=10)
     binning = DummyBinning()
     trainer.fit(model, binning, train_ds, val_ds)
     assert binning.fit_called
@@ -57,7 +57,7 @@ def test_trainer_accepts_learnable_bins():
     train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
     trainer = Trainer(TrainerConfig(max_epochs=0))
     binner = LearnableBinningScheme(5, 0.0, 1.0)
-    model = DummyModel(out_dim=5)
+    model = DummyModel(n_bins=5)
     trainer.fit(model, binner, train_ds, val_ds)
     assert isinstance(model.binner, LearnableBinningScheme)
 
@@ -80,7 +80,7 @@ def test_trainer_accepts_callable_binning():
         end = float(y.max())
         return BinningScheme(edges=torch.linspace(start, end, 3))
 
-    model = DummyModel(out_dim=2)
+    model = DummyModel(n_bins=2)
     trainer.fit(model, factory, train_ds, val_ds)
     assert isinstance(model.binner, BinningScheme)
 

--- a/tests/test_trainer_models.py
+++ b/tests/test_trainer_models.py
@@ -10,8 +10,8 @@ import importlib
 
 
 MODEL_CONFIGS = [
-    ("mlp", {"in_dim": 1, "out_dim": 10, "hidden_dims": [4]}),
-    ("logreg", {"in_dim": 1, "out_dim": 10}),
+    ("mlp", {"in_dim": 1, "n_bins": 10, "hidden_dims": [4]}),
+    ("logreg", {"in_dim": 1, "n_bins": 10}),
     ("gaussian_ls", {"in_dim": 1, "start": 0.0, "end": 1.0, "n_bins": 10}),
     (
         "mdn",


### PR DESCRIPTION
## Summary
- rename `out_dim` parameter to `n_bins` for all models
- update README to use the new argument
- update unit tests for renamed parameter

## Testing
- `pip install -e .`
- `pip install torchdiffeq`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872faf9a9c88324afa43f465e695968