### PR TITLE
Standardise binning scheme arguments

### DIFF
--- a/src/outdist/data/binning.py
+++ b/src/outdist/data/binning.py
@@ -163,10 +163,10 @@ class LearnableBinningScheme(BinningScheme, nn.Module):
 
     __hash__ = nn.Module.__hash__
 
-    def __init__(self, n_bins: int, y_min: float, y_max: float, init: str = "uniform") -> None:
+    def __init__(self, start: float, end: float, n_bins: int, init: str = "uniform") -> None:
         nn.Module.__init__(self)
-        self.y_min = float(y_min)
-        self.y_max = float(y_max)
+        self.start = float(start)
+        self.end = float(end)
         if init != "uniform":
             raise ValueError(f"Unknown init '{init}'")
         self.logits = nn.Parameter(torch.zeros(n_bins - 1))
@@ -176,14 +176,14 @@ class LearnableBinningScheme(BinningScheme, nn.Module):
     def edges(self) -> torch.Tensor:  # type: ignore[override]
         widths = torch.softmax(self.logits, dim=0)
         cumsum = torch.cumsum(widths, dim=0)
-        e_inner = self.y_min + (self.y_max - self.y_min) * cumsum
+        e_inner = self.start + (self.end - self.start) * cumsum
         device = self.logits.device
         dtype = self.logits.dtype
         return torch.cat(
             [
-                torch.tensor([self.y_min], device=device, dtype=dtype),
+                torch.tensor([self.start], device=device, dtype=dtype),
                 e_inner,
-                torch.tensor([self.y_max], device=device, dtype=dtype),
+                torch.tensor([self.end], device=device, dtype=dtype),
             ]
         )
 

--- a/tests/test_ensemble_trainer.py
+++ b/tests/test_ensemble_trainer.py
@@ -163,7 +163,7 @@ def test_ensemble_trainer_rejects_bootstrap_with_learnable_bins() -> None:
         ModelConfig(name="mlp", params={"in_dim": 1, "out_dim": 10, "hidden_dims": [4]})
     ]
     train_ds, val_ds, _ = make_dataset("dummy", n_samples=20)
-    binning = LearnableBinningScheme(5, 0.0, 1.0)
+    binning = LearnableBinningScheme(0.0, 1.0, 5)
     trainer_cfg = TrainerConfig(max_epochs=0, batch_size=4)
     ens_trainer = EnsembleTrainer(model_cfgs, trainer_cfg, bootstrap=True, n_jobs=1)
     with pytest.raises(ValueError):
@@ -185,7 +185,7 @@ def test_ensemble_trainer_aligns_incompatible_bins() -> None:
     train_ds, val_ds, _ = make_dataset("dummy", n_samples=40)
 
     def factory(_y: torch.Tensor) -> LearnableBinningScheme:
-        return LearnableBinningScheme(10, 0.0, 1.0)
+        return LearnableBinningScheme(0.0, 1.0, 10)
 
     trainer_cfg = TrainerConfig(max_epochs=1, batch_size=8)
     ens_trainer = EnsembleTrainer(model_cfgs, trainer_cfg, bootstrap=False, n_jobs=1)

--- a/tests/test_trainer_binning.py
+++ b/tests/test_trainer_binning.py
@@ -56,7 +56,7 @@ def test_trainer_fits_binning_before_training():
 def test_trainer_accepts_learnable_bins():
     train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
     trainer = Trainer(TrainerConfig(max_epochs=0))
-    binner = LearnableBinningScheme(5, 0.0, 1.0)
+    binner = LearnableBinningScheme(0.0, 1.0, 5)
     model = DummyModel(out_dim=5)
     trainer.fit(model, binner, train_ds, val_ds)
     assert isinstance(model.binner, LearnableBinningScheme)
@@ -65,7 +65,7 @@ def test_trainer_accepts_learnable_bins():
 def test_trainer_rejects_learnable_bins_for_nonmodule():
     train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
     trainer = Trainer(TrainerConfig(max_epochs=0))
-    binner = LearnableBinningScheme(5, 0.0, 1.0)
+    binner = LearnableBinningScheme(0.0, 1.0, 5)
     model = PlainModel()
     with pytest.raises(TypeError):
         trainer.fit(model, binner, train_ds, val_ds)


### PR DESCRIPTION
## Summary
- update `LearnableBinningScheme` to take `start`, `end`, `n_bins`
- align tests with new argument order

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872fb1cf5bc8324af0fb08328550e21