### PR TITLE
Unify binning scheme argument order

### DIFF
--- a/tests/test_ensemble_trainer.py
+++ b/tests/test_ensemble_trainer.py
@@ -163,7 +163,7 @@ def test_ensemble_trainer_rejects_bootstrap_with_learnable_bins() -> None:
         ModelConfig(name="mlp", params={"in_dim": 1, "n_bins": 10, "hidden_dims": [4]})
     ]
     train_ds, val_ds, _ = make_dataset("dummy", n_samples=20)
-    binning = LearnableBinningScheme(5, 0.0, 1.0)
+    binning = LearnableBinningScheme(0.0, 1.0, 5)
     trainer_cfg = TrainerConfig(max_epochs=0, batch_size=4)
     ens_trainer = EnsembleTrainer(model_cfgs, trainer_cfg, bootstrap=True, n_jobs=1)
     with pytest.raises(ValueError):
@@ -185,7 +185,7 @@ def test_ensemble_trainer_aligns_incompatible_bins() -> None:
     train_ds, val_ds, _ = make_dataset("dummy", n_samples=40)
 
     def factory(_y: torch.Tensor) -> LearnableBinningScheme:
-        return LearnableBinningScheme(10, 0.0, 1.0)
+        return LearnableBinningScheme(0.0, 1.0, 10)
 
     trainer_cfg = TrainerConfig(max_epochs=1, batch_size=8)
     ens_trainer = EnsembleTrainer(model_cfgs, trainer_cfg, bootstrap=False, n_jobs=1)

--- a/tests/test_trainer_binning.py
+++ b/tests/test_trainer_binning.py
@@ -56,7 +56,7 @@ def test_trainer_fits_binning_before_training():
 def test_trainer_accepts_learnable_bins():
     train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
     trainer = Trainer(TrainerConfig(max_epochs=0))
-    binner = LearnableBinningScheme(5, 0.0, 1.0)
+    binner = LearnableBinningScheme(0.0, 1.0, 5)
     model = DummyModel(n_bins=5)
     trainer.fit(model, binner, train_ds, val_ds)
     assert isinstance(model.binner, LearnableBinningScheme)
@@ -65,7 +65,7 @@ def test_trainer_accepts_learnable_bins():
 def test_trainer_rejects_learnable_bins_for_nonmodule():
     train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
     trainer = Trainer(TrainerConfig(max_epochs=0))
-    binner = LearnableBinningScheme(5, 0.0, 1.0)
+    binner = LearnableBinningScheme(0.0, 1.0, 5)
     model = PlainModel()
     with pytest.raises(TypeError):
         trainer.fit(model, binner, train_ds, val_ds)


### PR DESCRIPTION
## Summary
- standardise argument order for LearnableBinningScheme to `(start, end, n_bins)`
- update tests to use the new constructor signature

## Testing
- `pip install -e .`
- `pip install torchdiffeq nflows`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68730649fd0c832495d94da6067a6450