### PR TITLE
Add bin bootstrapping to trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Implemented strategies include:
   ```python
   binning = bootstrap(lambda s: QuantileBinning(s, 10).edges, y_train, n_bootstrap=20)
   ```
+  The trainer can perform this automatically:
+  ```python
+  trainer = Trainer(TrainerConfig(max_epochs=5), bootstrap_bins=True, n_bin_bootstraps=20)
+  ckpt = trainer.fit(model, lambda y: QuantileBinning(y, 10), train_ds, val_ds)
+  ```
 
 ## Calibration
 


### PR DESCRIPTION
## Summary
- add `bootstrap_bins` option to `Trainer` to compute averaged bin edges
- update README usage docs for bin bootstrapping
- test automatic bin bootstrapping

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68730c4b2f6c83248d408a5f8f564342