### PR TITLE
Ensure runtime dependencies are declared

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,17 @@ authors = [{ name = "Your Name", email = "you@example.com" }]
 description = "Package for discrete distributions over continuous outcomes"
 requires-python = ">=3.10"
 license = {file = "LICENSE"}
+dependencies = [
+    "torch",
+    "numpy",
+    "scikit-learn",
+    "nflows",
+    "torchdiffeq",
+]
+
+[project.optional-dependencies]
+lincde = ["lincde"]
+rfcde = ["rfcde"]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary
- list runtime dependencies in `pyproject.toml`
- specify optional extras for `lincde` and `rfcde`

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68731ae222108324afee4f1c23179c9a