### PR TITLE
Add synthetic dataset generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ from outdist import get_model, Trainer, make_dataset
 from outdist.configs.trainer import TrainerConfig
 from outdist.data.binning import EqualWidthBinning
 
-train_ds, val_ds, test_ds = make_dataset("dummy", n_samples=200)
+# use the built-in dummy classification dataset or a synthetic regression one
+train_ds, val_ds, test_ds = make_dataset("synthetic", n_samples=200, n_features=3)
 model = get_model("mlp", in_dim=1, n_bins=10)
 binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
 
@@ -35,8 +36,8 @@ print(results)
 Instead of writing Python code you can use the built-in CLI helpers:
 
 ```bash
-python -m outdist.cli.train --model mlp --dataset dummy --epochs 5
-python -m outdist.cli.evaluate --model mlp --dataset dummy --metrics nll accuracy
+python -m outdist.cli.train --model mlp --dataset synthetic --epochs 5
+python -m outdist.cli.evaluate --model mlp --dataset synthetic --metrics nll accuracy
 ```
 
 ## Models

--- a/tests/test_make_dataset.py
+++ b/tests/test_make_dataset.py
@@ -4,3 +4,10 @@ def test_make_dataset_splits_sum():
     train_ds, val_ds, test_ds = make_dataset("dummy", n_samples=50, splits=(0.6, 0.2, 0.2))
     total = len(train_ds) + len(val_ds) + len(test_ds)
     assert total == 50
+
+
+def test_synthetic_dataset_shapes():
+    train_ds, _, _ = make_dataset("synthetic", n_samples=30, n_features=4)
+    x, y = train_ds[0]
+    assert x.shape == (4,)
+    assert y.dim() == 0


### PR DESCRIPTION
## Summary
- implement synthetic continuous dataset with random feature relationships in `datasets.make_dataset`
- show synthetic dataset usage in README and CLI example
- test new dataset creation

## Testing
- `pytest tests/test_make_dataset.py::test_synthetic_dataset_shapes -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873437a6e808324afc97847f03a0327