### PR TITLE
Fix trainer with MLP by adding binning support

### DIFF
--- a/src/outdist/models/mlp.py
+++ b/src/outdist/models/mlp.py
@@ -11,6 +11,7 @@ from .base import BaseModel
 from ..configs.model import ModelConfig
 from ..utils import make_mlp
 from . import register_model
+from ..data import binning as binning_scheme
 
 
 @register_model("mlp")
@@ -20,11 +21,19 @@ class MLP(BaseModel):
     def __init__(
         self,
         in_dim: int = 1,
+        start: float = 0.0,
+        end: float = 1.0,
         n_bins: int = 10,
         hidden_dims: int | Sequence[int] = (32, 32),
+        *,
+        binner: binning_scheme.BinningScheme | None = None,
     ) -> None:
         super().__init__()
         self.net = make_mlp(in_dim, n_bins, hidden_dims)
+        if binner is None:
+            edges = torch.linspace(start, end, n_bins + 1)
+            binner = binning_scheme.BinningScheme(edges=edges)
+        self.binner = binner
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.net(x)
@@ -32,7 +41,14 @@ class MLP(BaseModel):
     @classmethod
     def default_config(cls) -> ModelConfig:
         return ModelConfig(
-            name="mlp", params={"in_dim": 1, "n_bins": 10, "hidden_dims": [32, 32]}
+            name="mlp",
+            params={
+                "in_dim": 1,
+                "start": 0.0,
+                "end": 1.0,
+                "n_bins": 10,
+                "hidden_dims": [32, 32],
+            },
         )
 
 


### PR DESCRIPTION
## Summary
- extend MLP model with optional BinningScheme
- update default config accordingly

## Testing
- `pytest -q`
- manual run of training example

------
https://chatgpt.com/codex/tasks/task_e_687352730c3c8324829a539e16288211