### PR TITLE
Switch trainer tests to synthetic dataset

### DIFF
--- a/src/outdist/models/evidential.py
+++ b/src/outdist/models/evidential.py
@@ -12,6 +12,7 @@ from .base import BaseModel
 from ..configs.model import ModelConfig
 from ..utils import make_mlp
 from . import register_model
+from ..data import binning as binning_scheme
 
 
 @register_model("evidential")
@@ -21,8 +22,12 @@ class EvidentialNet(BaseModel):
     def __init__(
         self,
         in_dim: int = 1,
+        start: float = 0.0,
+        end: float = 1.0,
         n_bins: int = 10,
         hidden_dims: int | Sequence[int] = (128, 128),
+        *,
+        binner: binning_scheme.BinningScheme | None = None,
     ) -> None:
         super().__init__()
         if isinstance(hidden_dims, int):
@@ -31,6 +36,10 @@ class EvidentialNet(BaseModel):
         last_dim = hidden_dims[-1]
         self.backbone = make_mlp(in_dim, last_dim, backbone_dims)
         self.evidence_head = nn.Linear(last_dim, n_bins)
+        if binner is None:
+            edges = torch.linspace(start, end, n_bins + 1)
+            binner = binning_scheme.BinningScheme(edges=edges)
+        self.binner = binner
 
     def forward(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
         features = self.backbone(x)
@@ -45,5 +54,11 @@ class EvidentialNet(BaseModel):
     def default_config(cls) -> ModelConfig:
         return ModelConfig(
             name="evidential",
-            params={"in_dim": 1, "n_bins": 10, "hidden_dims": [128, 128]},
+            params={
+                "in_dim": 1,
+                "start": 0.0,
+                "end": 1.0,
+                "n_bins": 10,
+                "hidden_dims": [128, 128],
+            },
         )

--- a/src/outdist/models/logistic_regression.py
+++ b/src/outdist/models/logistic_regression.py
@@ -8,19 +8,35 @@ from torch import nn
 from .base import BaseModel
 from ..configs.model import ModelConfig
 from . import register_model
+from ..data import binning as binning_scheme
 
 
 @register_model("logreg")
 class LogisticRegression(BaseModel):
     """Linear model mapping ``x`` to logits over discretised outcomes."""
 
-    def __init__(self, in_dim: int = 1, n_bins: int = 10) -> None:
+    def __init__(
+        self,
+        in_dim: int = 1,
+        start: float = 0.0,
+        end: float = 1.0,
+        n_bins: int = 10,
+        *,
+        binner: binning_scheme.BinningScheme | None = None,
+    ) -> None:
         super().__init__()
         self.linear = nn.Linear(in_dim, n_bins)
+        if binner is None:
+            edges = torch.linspace(start, end, n_bins + 1)
+            binner = binning_scheme.BinningScheme(edges=edges)
+        self.binner = binner
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.linear(x)
 
     @classmethod
     def default_config(cls) -> ModelConfig:
-        return ModelConfig(name="logreg", params={"in_dim": 1, "n_bins": 10})
+        return ModelConfig(
+            name="logreg",
+            params={"in_dim": 1, "start": 0.0, "end": 1.0, "n_bins": 10},
+        )

--- a/src/outdist/training/trainer.py
+++ b/src/outdist/training/trainer.py
@@ -141,7 +141,8 @@ class Trainer:
                 elif self.loss_fn is None and hasattr(model, "dsm_loss"):
                     loss = model.dsm_loss(x, y)
                 elif self.loss_fn is evidential_loss:
-                    loss = self.loss_fn(out["alpha"], y)
+                    targets = self._to_index(model, y)
+                    loss = self.loss_fn(out["alpha"], targets)
                 else:
                     targets = self._to_index(model, y)
                     loss = self.loss_fn(logits, targets)
@@ -281,7 +282,8 @@ class Trainer:
                 elif self.loss_fn is None and hasattr(model, "dsm_loss"):
                     _ = model.dsm_loss(x, y)
                 elif self.loss_fn is evidential_loss:
-                    _ = self.loss_fn(out["alpha"], y)
+                    targets = self._to_index(model, y)
+                    _ = self.loss_fn(out["alpha"], targets)
                 else:
                     targets = self._to_index(model, y)
                     _ = self.loss_fn(logits, targets)

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -34,7 +34,7 @@ def test_get_calibrator_instantiates_registered_calibrator():
 
 
 def test_trainer_fits_and_uses_calibrator():
-    train_ds, val_ds, test_ds = make_dataset("dummy", n_samples=20)
+    train_ds, val_ds, test_ds = make_dataset("synthetic", n_samples=20)
     binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
     calib_cfg = CalibratorConfig(name="dummy", params={"factor": 1.0})
     trainer = Trainer(TrainerConfig(max_epochs=1, batch_size=4), calibrator_cfg=calib_cfg)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import pytest
 from outdist.cli import train, evaluate
 from outdist.models import BaseModel, register_model, MODEL_REGISTRY
 from outdist.configs.model import ModelConfig
+from outdist.data import binning as binning_scheme
 
 
 @register_model("dummy_cli")
@@ -10,6 +11,8 @@ class DummyModel(BaseModel):
     def __init__(self, n_bins: int = 10):
         super().__init__()
         self.fc = torch.nn.Linear(1, n_bins)
+        edges = torch.linspace(0.0, 1.0, n_bins + 1)
+        self.binner = binning_scheme.BinningScheme(edges=edges)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.fc(x)
@@ -20,8 +23,8 @@ class DummyModel(BaseModel):
 
 
 def test_train_cli_runs(tmp_path, monkeypatch):
-    # run training for 1 epoch using dummy dataset
-    args = ["--model", "dummy_cli", "--dataset", "dummy", "--epochs", "0", "--batch-size", "2"]
+    # run training for 1 epoch using synthetic dataset
+    args = ["--model", "dummy_cli", "--dataset", "synthetic", "--epochs", "0", "--batch-size", "2"]
     monkeypatch.chdir(tmp_path)
     train.main(args)
 
@@ -31,13 +34,13 @@ def test_train_cli_runs(tmp_path, monkeypatch):
     [n for n in MODEL_REGISTRY.keys() if n not in {"lincde", "rfcde"}],
 )
 def test_train_cli_registered_models(name, tmp_path, monkeypatch):
-    args = ["--model", name, "--dataset", "dummy", "--epochs", "0", "--batch-size", "2"]
+    args = ["--model", name, "--dataset", "synthetic", "--epochs", "0", "--batch-size", "2"]
     monkeypatch.chdir(tmp_path)
     train.main(args)
 
 
 def test_evaluate_cli_runs(tmp_path, monkeypatch):
-    args = ["--model", "dummy_cli", "--dataset", "dummy", "--batch-size", "2", "--metrics", "nll"]
+    args = ["--model", "dummy_cli", "--dataset", "synthetic", "--batch-size", "2", "--metrics", "nll"]
     monkeypatch.chdir(tmp_path)
     evaluate.main(args)
 
@@ -55,7 +58,7 @@ def test_evaluate_cli_registered_models(name, tmp_path, monkeypatch):
         "--model",
         name,
         "--dataset",
-        "dummy",
+        "synthetic",
         "--batch-size",
         "2",
         "--metrics",

--- a/tests/test_ensemble_trainer.py
+++ b/tests/test_ensemble_trainer.py
@@ -140,7 +140,7 @@ def test_ensemble_trainer_runs(cfg_pair) -> None:
         ModelConfig(name=name1, params=kwargs1),
         ModelConfig(name=name2, params=kwargs2),
     ]
-    train_ds, val_ds, _ = make_dataset("dummy", n_samples=20)
+    train_ds, val_ds, _ = make_dataset("synthetic", n_samples=20)
     binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
     trainer_cfg = TrainerConfig(max_epochs=1, batch_size=4)
     ens_trainer = EnsembleTrainer(model_cfgs, trainer_cfg, bootstrap=False, n_jobs=1)
@@ -156,7 +156,7 @@ def test_stacked_ensemble_trainer_runs() -> None:
         ),
         ModelConfig(name="logreg", params={"in_dim": 1, "n_bins": 10}),
     ]
-    train_ds, val_ds, _ = make_dataset("dummy", n_samples=20)
+    train_ds, val_ds, _ = make_dataset("synthetic", n_samples=20)
     binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
     trainer_cfg = TrainerConfig(max_epochs=1, batch_size=4)
     ens_trainer = EnsembleTrainer(
@@ -174,7 +174,7 @@ def test_ensemble_trainer_rejects_bootstrap_with_learnable_bins() -> None:
     model_cfgs = [
         ModelConfig(name="mlp", params={"in_dim": 1, "n_bins": 10, "hidden_dims": [4]})
     ]
-    train_ds, val_ds, _ = make_dataset("dummy", n_samples=20)
+    train_ds, val_ds, _ = make_dataset("synthetic", n_samples=20)
     binning = LearnableBinningScheme(0.0, 1.0, 5)
     trainer_cfg = TrainerConfig(max_epochs=0, batch_size=4)
     ens_trainer = EnsembleTrainer(model_cfgs, trainer_cfg, bootstrap=True, n_jobs=1)
@@ -194,7 +194,7 @@ def test_ensemble_trainer_aligns_incompatible_bins() -> None:
         ),
     ]
 
-    train_ds, val_ds, _ = make_dataset("dummy", n_samples=40)
+    train_ds, val_ds, _ = make_dataset("synthetic", n_samples=40)
 
     def factory(_y: torch.Tensor) -> LearnableBinningScheme:
         return LearnableBinningScheme(0.0, 1.0, 10)

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -9,6 +9,7 @@ class DummyModel(BaseModel):
     def __init__(self, n_bins: int = 10):
         super().__init__()
         self.fc = torch.nn.Linear(1, n_bins)
+        self.binner = None
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.fc(x)
@@ -19,7 +20,7 @@ class DummyModel(BaseModel):
 
 
 def test_cross_validate_runs():
-    dataset, _, _ = make_dataset("dummy", n_samples=20)
+    dataset, _, _ = make_dataset("synthetic", n_samples=20)
 
     def model_factory():
         return DummyModel(n_bins=10)

--- a/tests/test_evidential_model.py
+++ b/tests/test_evidential_model.py
@@ -24,7 +24,7 @@ def test_evidential_loss_uniform_prior():
 
 
 def test_evidential_model_trains():
-    train_ds, val_ds, _ = make_dataset("dummy", n_samples=20)
+    train_ds, val_ds, _ = make_dataset("synthetic", n_samples=20)
     trainer = Trainer(TrainerConfig(max_epochs=1, batch_size=4), loss_fn=evidential_loss)
     binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
     model = get_model("evidential", in_dim=1, n_bins=10, hidden_dims=[4, 4])

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -24,7 +24,7 @@ class CountingLogger(TrainingLogger):
 
 
 def test_trainer_uses_logger() -> None:
-    train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
+    train_ds, val_ds, _ = make_dataset("synthetic", n_samples=10)
     logger = CountingLogger()
     trainer = Trainer(TrainerConfig(max_epochs=1, batch_size=4), logger=logger)
     binning = EqualWidthBinning(0.0, 10.0, n_bins=10)

--- a/tests/test_trainer_binning.py
+++ b/tests/test_trainer_binning.py
@@ -50,7 +50,7 @@ class PlainModel:
 
 
 def test_trainer_fits_binning_before_training():
-    train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
+    train_ds, val_ds, _ = make_dataset("synthetic", n_samples=10)
     trainer = Trainer(TrainerConfig(max_epochs=0))
     model = DummyModel(n_bins=10)
     binning = DummyBinning()
@@ -59,7 +59,7 @@ def test_trainer_fits_binning_before_training():
 
 
 def test_trainer_accepts_learnable_bins():
-    train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
+    train_ds, val_ds, _ = make_dataset("synthetic", n_samples=10)
     trainer = Trainer(TrainerConfig(max_epochs=0))
     binner = LearnableBinningScheme(0.0, 1.0, 5)
     model = DummyModel(n_bins=5)
@@ -68,7 +68,7 @@ def test_trainer_accepts_learnable_bins():
 
 
 def test_trainer_rejects_learnable_bins_for_nonmodule():
-    train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
+    train_ds, val_ds, _ = make_dataset("synthetic", n_samples=10)
     trainer = Trainer(TrainerConfig(max_epochs=0))
     binner = LearnableBinningScheme(0.0, 1.0, 5)
     model = PlainModel()
@@ -77,7 +77,7 @@ def test_trainer_rejects_learnable_bins_for_nonmodule():
 
 
 def test_trainer_accepts_callable_binning():
-    train_ds, val_ds, _ = make_dataset("dummy", n_samples=10)
+    train_ds, val_ds, _ = make_dataset("synthetic", n_samples=10)
     trainer = Trainer(TrainerConfig(max_epochs=0))
 
     def factory(y: torch.Tensor) -> BinningScheme:
@@ -92,7 +92,7 @@ def test_trainer_accepts_callable_binning():
 
 def test_trainer_bootstraps_binning():
     torch.manual_seed(0)
-    train_ds, val_ds, _ = make_dataset("dummy", n_samples=20)
+    train_ds, val_ds, _ = make_dataset("synthetic", n_samples=20)
 
     def factory(y: torch.Tensor) -> BinningScheme:
         return QuantileBinning(y.to(torch.float), 3)
@@ -111,7 +111,7 @@ def test_trainer_bootstraps_binning():
 
 
 def test_trainer_bootstrap_rejects_learnable():
-    train_ds, val_ds, _ = make_dataset("dummy", n_samples=20)
+    train_ds, val_ds, _ = make_dataset("synthetic", n_samples=20)
 
     def factory(_y: torch.Tensor) -> LearnableBinningScheme:
         return LearnableBinningScheme(0.0, 1.0, 5)

--- a/tests/test_trainer_models.py
+++ b/tests/test_trainer_models.py
@@ -131,7 +131,7 @@ def test_model_can_train_with_trainer(name: str, kwargs: dict) -> None:
         train_ds, val_ds = torch.utils.data.random_split(dataset, [16, 4])
         trainer = Trainer(TrainerConfig(max_epochs=1, batch_size=4), loss_fn=None)
     else:
-        train_ds, val_ds, _ = make_dataset("dummy", n_samples=20)
+        train_ds, val_ds, _ = make_dataset("synthetic", n_samples=20)
         trainer = Trainer(TrainerConfig(max_epochs=1, batch_size=4))
     binning = EqualWidthBinning(0.0, 10.0, n_bins=10)
     model = get_model(name, **kwargs)


### PR DESCRIPTION
## Summary
- use the synthetic dataset in trainer-related tests
- equip LogisticRegression and EvidentialNet with binner support
- discretise targets for evidential loss
- update dummy evaluator model for continuous data
- fix CLI dummy model binner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687371119c98832484e9465caf4a5dc4