### PR TITLE
Add Kernel-Mixture Network model

### DIFF
--- a/src/outdist/models/__init__.py
+++ b/src/outdist/models/__init__.py
@@ -51,4 +51,5 @@ from . import evidential  # noqa: F401
 from . import flow_cde  # noqa: F401
 from . import diffusion_cde  # noqa: F401
 from . import iqn_model  # noqa: F401
+from . import kmn_model  # noqa: F401
 

--- a/src/outdist/models/kmn_model.py
+++ b/src/outdist/models/kmn_model.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributions import Normal
+
+from ..data.binning import BinningScheme
+from .base import BaseModel
+from ..configs.model import ModelConfig
+from . import register_model
+
+__all__ = ["KMNModel", "make_centres"]
+
+
+# ------------------------------------------------------------------
+# Helper to choose kernel centres
+# ------------------------------------------------------------------
+def make_centres(y_train: torch.Tensor, k: int, *, method: str = "quantile") -> torch.Tensor:
+    if method == "quantile":
+        qs = torch.linspace(0.0, 1.0, k + 2, device=y_train.device)[1:-1]
+        return torch.quantile(y_train.flatten(), qs)
+    raise ValueError(f"Unknown centre initialisation '{method}'")
+
+
+class _KMNHead(nn.Module):
+    """Neural network head predicting mixture weights and a global scale."""
+
+    def __init__(self, in_dim: int, centres: torch.Tensor, *, hidden=(128, 128), log_sigma_init: float = -0.5) -> None:
+        super().__init__()
+        self.register_buffer("centres", centres)
+        self.log_sigma = nn.Parameter(torch.tensor(log_sigma_init))
+
+        layers: list[nn.Module] = []
+        last = in_dim
+        for h in hidden:
+            layers.append(nn.Linear(last, h))
+            layers.append(nn.ReLU())
+            last = h
+        self.feature = nn.Sequential(*layers)
+        self.out = nn.Linear(last, centres.numel())
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = self.out(self.feature(x))
+        weights = F.softmax(logits, dim=-1)
+        return weights, self.log_sigma.exp()
+
+
+@register_model("kmn")
+class KMNModel(BaseModel):
+    """Kernel-Mixture Network producing logits over fixed bins."""
+
+    def __init__(
+        self,
+        dim_x: int = 1,
+        binner: BinningScheme | None = None,
+        *,
+        centres: torch.Tensor | None = None,
+        n_kernels: int = 64,
+        hidden=(128, 128),
+        log_sigma_init: float = -0.5,
+    ) -> None:
+        super().__init__()
+        if centres is None:
+            centres = torch.linspace(0.0, 1.0, n_kernels)
+        if binner is None:
+            edges = torch.linspace(0.0, 1.0, 11)
+            binner = BinningScheme(edges=edges)
+        self.binner = binner
+        self.head = _KMNHead(dim_x, centres, hidden=hidden, log_sigma_init=log_sigma_init)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        weights, sigma = self.head(x)
+        dist = Normal(self.head.centres, sigma)
+        edges = self.binner.edges.to(x)
+        cdf = dist.cdf(edges.unsqueeze(-1)).transpose(0, 1)
+        p_bin = (cdf[..., 1:] - cdf[..., :-1]) * weights.unsqueeze(-1)
+        logits = (p_bin.sum(dim=1) + 1e-12).log()
+        return logits
+
+    @classmethod
+    def default_config(cls) -> ModelConfig:
+        return ModelConfig(
+            name="kmn",
+            params={"dim_x": 1, "hidden": [128, 128], "n_kernels": 64},
+        )

--- a/tests/test_kmn_model.py
+++ b/tests/test_kmn_model.py
@@ -1,0 +1,31 @@
+import torch
+from outdist.models import get_model
+from outdist.models.kmn_model import KMNModel, make_centres
+from outdist.data.binning import BinningScheme
+
+
+def test_kmn_forward_shape():
+    y_train = torch.linspace(0, 1, 100)
+    centres = make_centres(y_train, k=4)
+    edges = torch.linspace(0.0, 1.0, 6)
+    binner = BinningScheme(edges=edges)
+    model = get_model(
+        "kmn",
+        dim_x=2,
+        binner=binner,
+        centres=centres,
+        hidden=[16],
+    )
+    x = torch.randn(3, 2)
+    logits = model(x)
+    assert logits.shape == (3, 5)
+
+
+def test_default_config_instantiates_kmn():
+    cfg = KMNModel.default_config()
+    y_train = torch.linspace(0, 1, 50)
+    centres = make_centres(y_train, k=cfg.params.get("n_kernels", 1))
+    edges = torch.linspace(0.0, 1.0, 5)
+    binner = BinningScheme(edges=edges)
+    model = get_model(cfg, binner=binner, centres=centres)
+    assert isinstance(model, KMNModel)


### PR DESCRIPTION
## Summary
- implement `KMNModel` with helper utilities and defaults
- register KMN model in the model registry
- test KMN forward pass and default configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68748f8aeb048324925f31f73d6e8284