### PR TITLE
Improve test coverage

### DIFF
--- a/tests/test_dirichlet_utils.py
+++ b/tests/test_dirichlet_utils.py
@@ -1,0 +1,14 @@
+import torch
+from outdist.dirichlet import total_uncertainty, epistemic_entropy
+
+
+def test_dirichlet_measures():
+    alpha = torch.tensor([[1.0, 2.0], [0.5, 1.5]])
+    tu = total_uncertainty(alpha)
+    expected_tu = 2 / (alpha.sum(-1) + 1)
+    assert torch.allclose(tu, expected_tu)
+
+    ee = epistemic_entropy(alpha)
+    p = alpha / alpha.sum(-1, keepdim=True)
+    expected_ee = (-p * p.log()).sum(-1)
+    assert torch.allclose(ee, expected_ee)

--- a/tests/test_ensembles_methods.py
+++ b/tests/test_ensembles_methods.py
@@ -1,0 +1,70 @@
+import torch
+import math
+
+from outdist.models import get_model
+from outdist.ensembles.average import AverageEnsemble
+from outdist.ensembles.stacked import StackedEnsemble, learn_weights
+
+
+def _dummy_models(n=2, in_dim=1, n_bins=3):
+    return [get_model("logreg", in_dim=in_dim, n_bins=n_bins) for _ in range(n)]
+
+
+def test_average_ensemble_methods():
+    models = _dummy_models()
+    ens = AverageEnsemble(models)
+    x = torch.randn(4, 1)
+    y = torch.randint(0, 3, (4,))
+
+    logits = ens.bin_logits(x)
+    assert logits.shape == (4, 3)
+
+    lp = ens.log_prob(x, y)
+    expected = torch.logsumexp(
+        torch.stack([
+            torch.log_softmax(m(x), dim=-1).gather(-1, y[:, None]).squeeze(-1)
+            for m in models
+        ]),
+        dim=0,
+    ) - math.log(len(models))
+    assert torch.allclose(lp, expected)
+
+    samples = ens.sample(x[:1], n=5)
+    assert samples.shape[0] == 5
+
+
+def test_stacked_ensemble_methods_and_weights():
+    models = _dummy_models()
+    weights = torch.tensor([0.6, 0.4])
+    ens = StackedEnsemble(models, weights)
+    x = torch.randn(3, 1)
+    y = torch.randint(0, 3, (3,))
+
+    logits = ens.bin_logits(x)
+    expected_probs = torch.stack([m(x).softmax(-1) for m in models])
+    expected = torch.einsum("k,knb->nb", weights, expected_probs)
+    expected_logits = (expected + 1e-12).log()
+    assert torch.allclose(logits, expected_logits)
+
+    lp = ens.log_prob(x, y)
+    lps = torch.stack([
+        torch.log_softmax(m(x), dim=-1).gather(-1, y[:, None]).squeeze(-1)
+        for m in models
+    ])
+    expected_lp = torch.logsumexp(lps + weights.log()[:, None], dim=0) - math.log(weights.sum())
+    assert torch.allclose(lp, expected_lp)
+
+    samples = ens.sample(x[:1], n=4)
+    assert samples.shape[0] == 4
+
+
+
+def test_learn_weights():
+    models = _dummy_models(in_dim=1)
+    X_val = torch.randn(5, 1)
+    y_val = torch.randint(0, 3, (5,))
+
+    w = learn_weights(models, X_val.numpy(), y_val.numpy(), l2=1e-2)
+    assert w.shape[0] == len(models)
+    assert torch.isclose(w.sum(), torch.tensor(1.0), atol=1e-5)
+    assert torch.all(w >= 0)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -39,3 +39,24 @@ def test_trainer_uses_logger() -> None:
 
 def test_console_logger_subclass() -> None:
     assert issubclass(ConsoleLogger, TrainingLogger)
+
+class DummyCollectLogger(TrainingLogger):
+    def __init__(self):
+        super().__init__()
+        self.avgs = []
+
+    def on_epoch_end(self, epoch: int, avg_loss: float) -> None:
+        self.avgs.append(avg_loss)
+
+
+def test_training_logger_computes_average():
+    logger = DummyCollectLogger()
+    logger.start_epoch(0, num_batches=3)
+    logger.log_batch(0, 1.0)
+    logger.log_batch(1, 2.0)
+    logger.log_batch(2, 3.0)
+    logger.end_epoch(0)
+    assert logger.avgs == [2.0]
+
+    logger.start_epoch(1, num_batches=1)
+    assert logger.losses == []


### PR DESCRIPTION
## Summary
- add unit tests for Dirichlet utilities
- exercise AverageEnsemble and StackedEnsemble behaviour
- test TrainingLogger average computation

## Testing
- `pytest -q`
- `pytest --cov=outdist -q`

------
https://chatgpt.com/codex/tasks/task_e_6874eb86fc588324aa6cc314a9ecfa5a