### PR TITLE
Add MeanFlow model

### DIFF
--- a/src/outdist/models/__init__.py
+++ b/src/outdist/models/__init__.py
@@ -54,3 +54,4 @@ from . import iqn_model  # noqa: F401
 from . import kmn_model  # noqa: F401
 
 from . import imm_jump  # noqa: F401
+from . import mean_flow  # noqa: F401

--- a/src/outdist/models/mean_flow.py
+++ b/src/outdist/models/mean_flow.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+import math
+import torch
+from torch import nn
+from torch.nn import functional as F
+from torch.autograd.functional import jvp
+
+from . import register_model
+from ..utils import make_mlp
+from ..data.binning import BinningScheme
+
+
+@register_model("mean_flow")
+class MeanFlow(nn.Module):
+    """Predict the average velocity from time ``s`` to ``t``."""
+
+    def __init__(
+        self,
+        in_dim: int = 1,
+        hidden_dims: tuple[int, ...] | list[int] = (128, 128),
+        time_embed_dim: int = 32,
+        sigma: float = 1.0,
+        step: float = 0.1,
+        binner: BinningScheme | None = None,
+        start: float = 0.0,
+        end: float = 1.0,
+        n_bins: int = 10,
+    ) -> None:
+        super().__init__()
+        self.sigma = sigma
+        self.step = step
+        if binner is None:
+            edges = torch.linspace(start, end, n_bins + 1)
+            binner = BinningScheme(edges=edges)
+        self.binner = binner
+
+        self.time_emb = nn.Sequential(
+            nn.Linear(2, time_embed_dim),
+            nn.SiLU(),
+        )
+        self.core = make_mlp(in_dim + 1 + time_embed_dim, 1, hidden_dims)
+
+    # ----------------------------------------------------------- #
+    def phi(
+        self, x: torch.Tensor, y: torch.Tensor, s: torch.Tensor, t: torch.Tensor
+    ) -> torch.Tensor:
+        """Predict the average velocity from ``s`` to ``t``."""
+        y = y.squeeze(-1)
+        te = torch.stack([torch.cos(math.pi * s), torch.sin(math.pi * s)], dim=-1)
+        te = self.time_emb(te)
+        inp = torch.cat([x, y[:, None], te], dim=-1)
+        return self.core(inp).squeeze(-1)
+
+    # ----------------------------------------------------------- #
+    def mf_loss(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """Mean-Flow regression loss implementing Eq.(★)."""
+        y = y.squeeze(-1)
+        B = y.size(0)
+        s = torch.rand(B, device=y.device) * (1 - self.step) + self.step
+        t = s - self.step
+
+        eps = torch.randn_like(y) * self.sigma
+        y_s = torch.sqrt(1 - s) * y + torch.sqrt(s) * eps
+
+        v_s = self.phi(x, y_s, s, s)
+
+        def f(y_in: torch.Tensor) -> torch.Tensor:
+            return self.phi(x, y_in, s, s)
+
+        jvp_val = jvp(f, y_s, v_s, create_graph=False)[1]
+        target = v_s - (s - t) * jvp_val
+        target = target.detach()
+
+        v_bar_pred = self.phi(x, y_s, s, t)
+        return F.mse_loss(v_bar_pred, target)
+
+    # ----------------------------------------------------------- #
+    @torch.no_grad()
+    def predict_logits(
+        self, x: torch.Tensor, n_particles: int = 256, steps: int = 2
+    ) -> torch.Tensor:
+        """Few-step Mean-Flow sampling and histogramming."""
+        B = x.size(0)
+        device = x.device
+        y = torch.randn(B, n_particles, device=device) * self.sigma
+        s = torch.ones(B * n_particles, device=device)
+
+        for _ in range(steps):
+            t = (s - self.step).clamp(min=0)
+            y = y.view(-1)
+            v_bar = self.phi(
+                x.repeat_interleave(n_particles, 0),
+                y,
+                s,
+                t,
+            )
+            y = (y - (s - t) * v_bar).view(B, n_particles)
+            s = t
+
+        idx = self.binner.to_index(y)
+        K = self.binner.n_bins
+        hist = torch.zeros(B, K, device=device)
+        hist.scatter_add_(1, idx, torch.ones_like(idx, dtype=hist.dtype))
+        probs = (hist + 0.5) / (n_particles + 0.5 * K)
+        return probs.log()
+
+    # ----------------------------------------------------------- #
+    def __call__(self, *args, **kw):
+        raise RuntimeError("Use mf_loss() for training or predict_logits() for eval.")
+
+    @classmethod
+    def default_config(cls):
+        from ..configs.model import ModelConfig
+
+        return ModelConfig(
+            name="mean_flow",
+            params={
+                "in_dim": 1,
+                "hidden_dims": [128, 128],
+                "time_embed_dim": 32,
+                "sigma": 1.0,
+                "step": 0.1,
+                "start": 0.0,
+                "end": 1.0,
+                "n_bins": 10,
+            },
+        )

--- a/src/outdist/training/trainer.py
+++ b/src/outdist/training/trainer.py
@@ -138,6 +138,8 @@ class Trainer:
                     loss = model.imm_loss(x, y)
                 elif self.loss_fn is None and hasattr(model, "dsm_loss"):
                     loss = model.dsm_loss(x, y)
+                elif hasattr(model, "mf_loss"):
+                    loss = model.mf_loss(x, y)
                 else:
                     out = model(x)
                     logits = out
@@ -169,7 +171,9 @@ class Trainer:
                 for batch in val_loader:
                     x, y = batch
                     x = x.to(self.device)
-                    if hasattr(model, "imm_loss") and hasattr(model, "predict_logits"):
+                    if (
+                        hasattr(model, "imm_loss") or hasattr(model, "mf_loss")
+                    ) and hasattr(model, "predict_logits"):
                         logits = model.predict_logits(x)
                     else:
                         out = model(x)
@@ -244,7 +248,9 @@ class Trainer:
             for batch in loader:
                 x, y = batch
                 x = x.to(self.device)
-                if hasattr(model, "imm_loss") and hasattr(model, "predict_logits"):
+                if (
+                    hasattr(model, "imm_loss") or hasattr(model, "mf_loss")
+                ) and hasattr(model, "predict_logits"):
                     logits = model.predict_logits(x)
                 else:
                     out = model(x)
@@ -288,6 +294,8 @@ class Trainer:
                     _ = model.imm_loss(x, y)
                 elif self.loss_fn is None and hasattr(model, "dsm_loss"):
                     _ = model.dsm_loss(x, y)
+                elif hasattr(model, "mf_loss"):
+                    _ = model.mf_loss(x, y)
                 else:
                     out = model(x)
                     logits = out

--- a/tests/test_mean_flow_model.py
+++ b/tests/test_mean_flow_model.py
@@ -1,0 +1,28 @@
+import torch
+from outdist.models import get_model
+from outdist.models.mean_flow import MeanFlow
+from outdist.data.binning import EqualWidthBinning
+from outdist.training.trainer import Trainer
+from outdist.configs.trainer import TrainerConfig
+
+
+def test_predict_logits_shape():
+    binning = EqualWidthBinning(0.0, 1.0, n_bins=5)
+    model = get_model("mean_flow", in_dim=2, step=0.2)
+    model.binner = binning
+    x = torch.randn(3, 2)
+    logits = model.predict_logits(x, steps=1)
+    assert logits.shape == (3, 5)
+
+
+def test_trainer_runs_with_mean_flow():
+    x = torch.randn(20, 2)
+    y = torch.randn(20, 1)
+    dataset = torch.utils.data.TensorDataset(x, y)
+    train_ds, val_ds = torch.utils.data.random_split(dataset, [16, 4])
+    binning = EqualWidthBinning(0.0, 1.0, n_bins=5)
+    trainer = Trainer(TrainerConfig(max_epochs=1, batch_size=4), loss_fn=None)
+    model = get_model("mean_flow", in_dim=2, step=0.2)
+    ckpt = trainer.fit(model, binning, train_ds, val_ds)
+    assert ckpt.epoch == 1
+    assert isinstance(ckpt.model, MeanFlow)

--- a/tests/test_trainer_models.py
+++ b/tests/test_trainer_models.py
@@ -126,12 +126,19 @@ MODEL_CONFIGS = [
             "step": 0.2,
         },
     ),
+    (
+        "mean_flow",
+        {
+            "in_dim": 1,
+            "step": 0.2,
+        },
+    ),
 ]
 
 
 @pytest.mark.parametrize("name, kwargs", MODEL_CONFIGS)
 def test_model_can_train_with_trainer(name: str, kwargs: dict) -> None:
-    if name in ("diffusion", "imm_jump"):
+    if name in ("diffusion", "imm_jump", "mean_flow"):
         x = torch.randn(20, 1)
         y = torch.randn(20, 1)
         dataset = torch.utils.data.TensorDataset(x, y)


### PR DESCRIPTION
## Summary
- implement MeanFlow model for 1‑D mean-flow regression
- support `mf_loss` in Trainer
- register model
- add tests for MeanFlow and trainer integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68761cb6a8dc832496bc0cc64ae4a9f6