### PR TITLE
Add transformer model with distributional output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,22 +8,38 @@ This is `outdist` - a Python library for modeling discrete distributions over co
 
 ## Development Commands
 
+### Environment Setup
+This project uses `uv` for Python environment management. Always activate the virtual environment before running commands:
+
+```bash
+uv venv                   # Create virtual environment (first time only)
+source .venv/bin/activate # Activate virtual environment
+```
+
+Or run commands directly with uv:
+```bash
+uv run python -m pytest  # Run with uv (automatically uses correct environment)
+uv run python -c "..."   # Run Python scripts with uv
+```
+
 ### Installation and Setup
 ```bash
+uv sync                   # Install dependencies using uv
+# OR if using pip:
 pip install -e .
 ```
 
 ### Testing
 ```bash
-pytest                    # Run all tests
-pytest -k "test_name"     # Run specific test
-pytest tests/test_*.py    # Run specific test file
+uv run pytest                    # Run all tests
+uv run pytest -k "test_name"     # Run specific test
+uv run pytest tests/test_*.py    # Run specific test file
 ```
 
 ### CLI Usage
 ```bash
-python -m outdist.cli.train --model mlp --dataset synthetic --epochs 5
-python -m outdist.cli.evaluate --model mlp --dataset synthetic --metrics nll accuracy
+uv run python -m outdist.cli.train --model mlp --dataset synthetic --epochs 5
+uv run python -m outdist.cli.evaluate --model mlp --dataset synthetic --metrics nll accuracy
 ```
 
 ## Architecture
@@ -40,7 +56,7 @@ python -m outdist.cli.evaluate --model mlp --dataset synthetic --metrics nll acc
 #### Models (`src/outdist/models/`)
 - All models inherit from `BaseModel` and implement `forward(x) -> logits`
 - Models register themselves: `@register_model("name")`
-- Available models: `logreg`, `mlp`, `gaussian_ls`, `mdn`, `logistic_mixture`, `flow`, `ckde`, `quantile_rf`, `lincde`, `rfcde`, `imm_jump`, `evidential`
+- Available models: `logreg`, `mlp`, `gaussian_ls`, `mdn`, `logistic_mixture`, `flow`, `ckde`, `quantile_rf`, `lincde`, `rfcde`, `imm_jump`, `evidential`, `transformer`
 
 #### Binning (`src/outdist/data/binning.py`)
 - `EqualWidthBinning` - evenly spaced bins
@@ -95,3 +111,9 @@ ckpt = trainer.fit(model, binning, train_ds, val_ds)
 - Tests mirror the `src/` directory structure
 - Each model has corresponding `test_*_model.py` file
 - Use `pytest` for running tests
+
+### Testing Notes for Development
+- **Import Issues**: Some models have external dependencies (like `nflows`) that may not be installed, causing import errors when running full test suite
+- **Testing Strategy**: For testing new models in isolation, create standalone test files that import only the specific model components needed, avoiding the full model registry
+- **Simple Component Tests**: Use `python test_file.py` with minimal imports for quick validation of new model implementations
+- **Framework Integration**: Once basic functionality is verified, add proper pytest tests following the existing `test_*_model.py` pattern

--- a/src/outdist/models/__init__.py
+++ b/src/outdist/models/__init__.py
@@ -55,3 +55,4 @@ from . import kmn_model  # noqa: F401
 
 from . import imm_jump  # noqa: F401
 from . import mean_flow  # noqa: F401
+from . import transformer  # noqa: F401

--- a/src/outdist/models/transformer.py
+++ b/src/outdist/models/transformer.py
@@ -1,0 +1,237 @@
+"""Transformer model with distributional output."""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+import torch
+from torch import nn
+
+from .base import BaseModel
+from ..configs.model import ModelConfig
+from ..utils import make_mlp
+from . import register_model
+from ..data import binning as binning_scheme
+
+
+class MultiHeadAttention(nn.Module):
+    """Multi-head self-attention module."""
+
+    def __init__(self, d_model: int, n_heads: int, dropout: float = 0.1):
+        super().__init__()
+        assert d_model % n_heads == 0
+        
+        self.d_model = d_model
+        self.n_heads = n_heads
+        self.d_k = d_model // n_heads
+        
+        self.w_q = nn.Linear(d_model, d_model)
+        self.w_k = nn.Linear(d_model, d_model)
+        self.w_v = nn.Linear(d_model, d_model)
+        self.w_o = nn.Linear(d_model, d_model)
+        
+        self.dropout = nn.Dropout(dropout)
+        self.scale = math.sqrt(self.d_k)
+        
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        batch_size, seq_len, d_model = x.shape
+        
+        # Linear transformations and split into heads
+        q = self.w_q(x).view(batch_size, seq_len, self.n_heads, self.d_k).transpose(1, 2)
+        k = self.w_k(x).view(batch_size, seq_len, self.n_heads, self.d_k).transpose(1, 2)
+        v = self.w_v(x).view(batch_size, seq_len, self.n_heads, self.d_k).transpose(1, 2)
+        
+        # Scaled dot-product attention
+        scores = torch.matmul(q, k.transpose(-2, -1)) / self.scale
+        
+        if mask is not None:
+            scores = scores.masked_fill(mask == 0, -1e9)
+            
+        attn_weights = torch.softmax(scores, dim=-1)
+        attn_weights = self.dropout(attn_weights)
+        
+        # Apply attention to values
+        attn_output = torch.matmul(attn_weights, v)
+        
+        # Concatenate heads and put through final linear layer
+        attn_output = attn_output.transpose(1, 2).contiguous().view(
+            batch_size, seq_len, d_model
+        )
+        
+        return self.w_o(attn_output)
+
+
+class FeedForward(nn.Module):
+    """Position-wise feed-forward network."""
+    
+    def __init__(self, d_model: int, d_ff: int, dropout: float = 0.1):
+        super().__init__()
+        self.linear1 = nn.Linear(d_model, d_ff)
+        self.linear2 = nn.Linear(d_ff, d_model)
+        self.dropout = nn.Dropout(dropout)
+        self.activation = nn.ReLU()
+        
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear2(self.dropout(self.activation(self.linear1(x))))
+
+
+class TransformerBlock(nn.Module):
+    """Single transformer encoder block."""
+    
+    def __init__(self, d_model: int, n_heads: int, d_ff: int, dropout: float = 0.1):
+        super().__init__()
+        self.attention = MultiHeadAttention(d_model, n_heads, dropout)
+        self.feed_forward = FeedForward(d_model, d_ff, dropout)
+        self.norm1 = nn.LayerNorm(d_model)
+        self.norm2 = nn.LayerNorm(d_model)
+        self.dropout = nn.Dropout(dropout)
+        
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        # Self-attention with residual connection and layer norm
+        attn_output = self.attention(x, mask)
+        x = self.norm1(x + self.dropout(attn_output))
+        
+        # Feed-forward with residual connection and layer norm
+        ff_output = self.feed_forward(x)
+        x = self.norm2(x + self.dropout(ff_output))
+        
+        return x
+
+
+class PositionalEncoding(nn.Module):
+    """Positional encoding for transformer inputs."""
+    
+    def __init__(self, d_model: int, max_len: int = 5000):
+        super().__init__()
+        
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(torch.arange(0, d_model, 2).float() * 
+                           (-math.log(10000.0) / d_model))
+        
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0).transpose(0, 1)
+        
+        self.register_buffer('pe', pe)
+        
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.pe[:x.size(0), :]
+
+
+@register_model("transformer")
+class TransformerDistribution(BaseModel):
+    """Transformer model with distributional output.
+    
+    This model treats each input feature as a sequence element and uses
+    self-attention to model dependencies between features before predicting
+    the distribution over target bins.
+    """
+
+    def __init__(
+        self,
+        in_dim: int = 1,
+        start: float = 0.0,
+        end: float = 1.0,
+        n_bins: int = 10,
+        d_model: int = 64,
+        n_heads: int = 8,
+        n_layers: int = 2,
+        d_ff: int | None = None,
+        dropout: float = 0.1,
+        max_seq_len: int = 1000,
+        pooling: str = "mean",
+        *,
+        binner: binning_scheme.BinningScheme | None = None,
+    ) -> None:
+        super().__init__()
+        
+        if d_ff is None:
+            d_ff = d_model * 4
+            
+        self.in_dim = in_dim
+        self.d_model = d_model
+        self.pooling = pooling
+        
+        # Input embedding - project each feature to d_model dimensions
+        self.input_embedding = nn.Linear(1, d_model)
+        
+        # Positional encoding
+        self.pos_encoding = PositionalEncoding(d_model, max_seq_len)
+        
+        # Transformer layers
+        self.transformer_blocks = nn.ModuleList([
+            TransformerBlock(d_model, n_heads, d_ff, dropout)
+            for _ in range(n_layers)
+        ])
+        
+        # Output projection to bin logits
+        self.output_projection = nn.Linear(d_model, n_bins)
+        
+        # Dropout
+        self.dropout = nn.Dropout(dropout)
+        
+        # Binning scheme
+        if binner is None:
+            edges = torch.linspace(start, end, n_bins + 1)
+            binner = binning_scheme.BinningScheme(edges=edges)
+        self.binner = binner
+        
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        batch_size, n_features = x.shape
+        
+        # Reshape input to treat each feature as a sequence element
+        # x: (batch_size, n_features) -> (batch_size, n_features, 1)
+        x = x.unsqueeze(-1)
+        
+        # Input embedding: (batch_size, n_features, 1) -> (batch_size, n_features, d_model)
+        x = self.input_embedding(x)
+        
+        # Add positional encoding
+        x = x.transpose(0, 1)  # (n_features, batch_size, d_model)
+        x = self.pos_encoding(x)
+        x = x.transpose(0, 1)  # (batch_size, n_features, d_model)
+        
+        # Apply dropout
+        x = self.dropout(x)
+        
+        # Pass through transformer blocks
+        for transformer_block in self.transformer_blocks:
+            x = transformer_block(x)
+        
+        # Pool across sequence dimension
+        if self.pooling == "mean":
+            x = x.mean(dim=1)  # (batch_size, d_model)
+        elif self.pooling == "max":
+            x = x.max(dim=1)[0]  # (batch_size, d_model)
+        elif self.pooling == "sum":
+            x = x.sum(dim=1)  # (batch_size, d_model)
+        elif self.pooling == "last":
+            x = x[:, -1, :]  # (batch_size, d_model)
+        else:
+            raise ValueError(f"Unknown pooling method: {self.pooling}")
+        
+        # Project to bin logits
+        logits = self.output_projection(x)  # (batch_size, n_bins)
+        
+        return logits
+
+    @classmethod
+    def default_config(cls) -> ModelConfig:
+        return ModelConfig(
+            name="transformer",
+            params={
+                "in_dim": 1,
+                "start": 0.0,
+                "end": 1.0,
+                "n_bins": 10,
+                "d_model": 64,
+                "n_heads": 8,
+                "n_layers": 2,
+                "d_ff": None,  # Will default to d_model * 4
+                "dropout": 0.1,
+                "max_seq_len": 1000,
+                "pooling": "mean",
+            },
+        )

--- a/tests/test_transformer_model.py
+++ b/tests/test_transformer_model.py
@@ -1,0 +1,235 @@
+import torch
+import pytest
+from outdist.models import get_model
+from outdist.models.transformer import TransformerDistribution
+
+
+def test_transformer_forward_shape():
+    """Test that transformer model outputs correct shape."""
+    model = get_model(
+        "transformer",
+        in_dim=3,
+        start=0.0,
+        end=1.0,
+        n_bins=4,
+        d_model=16,
+        n_heads=2,
+        n_layers=1,
+        pooling="mean",
+    )
+    x = torch.randn(2, 3)
+    logits = model(x)
+    assert logits.shape == (2, 4)
+
+
+def test_transformer_different_pooling_methods():
+    """Test that different pooling methods work correctly."""
+    pooling_methods = ["mean", "max", "sum", "last"]
+    
+    for pooling in pooling_methods:
+        model = get_model(
+            "transformer",
+            in_dim=5,
+            n_bins=3,
+            d_model=8,
+            n_heads=2,
+            n_layers=1,
+            pooling=pooling,
+        )
+        x = torch.randn(3, 5)
+        logits = model(x)
+        assert logits.shape == (3, 3)
+
+
+def test_transformer_different_architectures():
+    """Test transformer with different architectural parameters."""
+    # Test with different number of layers
+    model = get_model(
+        "transformer",
+        in_dim=2,
+        n_bins=5,
+        d_model=32,
+        n_heads=4,
+        n_layers=3,
+        dropout=0.2,
+    )
+    x = torch.randn(4, 2)
+    logits = model(x)
+    assert logits.shape == (4, 5)
+    
+    # Test with custom d_ff
+    model = get_model(
+        "transformer",
+        in_dim=2,
+        n_bins=5,
+        d_model=16,
+        n_heads=2,
+        n_layers=2,
+        d_ff=32,
+    )
+    x = torch.randn(4, 2)
+    logits = model(x)
+    assert logits.shape == (4, 5)
+
+
+def test_transformer_single_feature():
+    """Test transformer with single input feature."""
+    model = get_model(
+        "transformer",
+        in_dim=1,
+        n_bins=3,
+        d_model=8,
+        n_heads=2,
+        n_layers=1,
+    )
+    x = torch.randn(5, 1)
+    logits = model(x)
+    assert logits.shape == (5, 3)
+
+
+def test_transformer_batch_consistency():
+    """Test that transformer produces consistent outputs across batch sizes."""
+    model = get_model(
+        "transformer",
+        in_dim=3,
+        n_bins=4,
+        d_model=16,
+        n_heads=2,
+        n_layers=1,
+    )
+    
+    # Test single sample
+    x_single = torch.randn(1, 3)
+    logits_single = model(x_single)
+    assert logits_single.shape == (1, 4)
+    
+    # Test batch
+    x_batch = torch.randn(10, 3)
+    logits_batch = model(x_batch)
+    assert logits_batch.shape == (10, 4)
+
+
+def test_transformer_gradient_flow():
+    """Test that gradients flow properly through the transformer."""
+    model = get_model(
+        "transformer",
+        in_dim=2,
+        n_bins=3,
+        d_model=8,
+        n_heads=2,
+        n_layers=1,
+    )
+    x = torch.randn(2, 2, requires_grad=True)
+    logits = model(x)
+    loss = logits.sum()
+    loss.backward()
+    
+    # Check that gradients exist
+    assert x.grad is not None
+    assert x.grad.shape == x.shape
+    
+    # Check that model parameters have gradients
+    for param in model.parameters():
+        if param.requires_grad:
+            assert param.grad is not None
+
+
+def test_transformer_attention_mask_shapes():
+    """Test internal attention computations (implicitly through forward pass)."""
+    model = get_model(
+        "transformer",
+        in_dim=4,
+        n_bins=2,
+        d_model=12,
+        n_heads=3,
+        n_layers=2,
+    )
+    
+    # Test with different input sizes
+    for batch_size in [1, 5, 10]:
+        x = torch.randn(batch_size, 4)
+        logits = model(x)
+        assert logits.shape == (batch_size, 2)
+
+
+def test_transformer_invalid_pooling():
+    """Test that invalid pooling method raises error."""
+    with pytest.raises(ValueError, match="Unknown pooling method"):
+        model = get_model(
+            "transformer",
+            in_dim=2,
+            n_bins=3,
+            d_model=8,
+            n_heads=2,
+            n_layers=1,
+            pooling="invalid",
+        )
+        x = torch.randn(1, 2)
+        model(x)
+
+
+def test_transformer_head_dimension_compatibility():
+    """Test that d_model is compatible with n_heads."""
+    # This should work - d_model divisible by n_heads
+    model = get_model(
+        "transformer",
+        in_dim=2,
+        n_bins=3,
+        d_model=16,
+        n_heads=4,
+        n_layers=1,
+    )
+    x = torch.randn(2, 2)
+    logits = model(x)
+    assert logits.shape == (2, 3)
+    
+    # This should fail - d_model not divisible by n_heads
+    with pytest.raises(AssertionError):
+        model = get_model(
+            "transformer",
+            in_dim=2,
+            n_bins=3,
+            d_model=15,  # Not divisible by 4
+            n_heads=4,
+            n_layers=1,
+        )
+
+
+def test_default_config_instantiates_transformer():
+    """Test that default configuration creates valid transformer."""
+    cfg = TransformerDistribution.default_config()
+    model = get_model(cfg)
+    assert isinstance(model, TransformerDistribution)
+    
+    # Test that it can do forward pass
+    x = torch.randn(2, 1)  # Default in_dim is 1
+    logits = model(x)
+    assert logits.shape == (2, 10)  # Default n_bins is 10
+
+
+def test_transformer_reproducibility():
+    """Test that transformer outputs are reproducible with same seed."""
+    torch.manual_seed(42)
+    model1 = get_model(
+        "transformer",
+        in_dim=3,
+        n_bins=4,
+        d_model=16,
+        n_heads=2,
+        n_layers=1,
+    )
+    x = torch.randn(2, 3)
+    logits1 = model1(x)
+    
+    torch.manual_seed(42)
+    model2 = get_model(
+        "transformer",
+        in_dim=3,
+        n_bins=4,
+        d_model=16,
+        n_heads=2,
+        n_layers=1,
+    )
+    logits2 = model2(x)
+    
+    assert torch.allclose(logits1, logits2, atol=1e-6)


### PR DESCRIPTION
- Implement TransformerDistribution model with multi-head self-attention
- Add support for multiple transformer layers with residual connections
- Include positional encoding for sequence modeling of input features
- Support configurable pooling strategies (mean, max, sum, last)
- Add comprehensive test suite covering all functionality and edge cases
- Register model as 'transformer' in model registry
- Update documentation and development notes

Features:
- Multi-head attention mechanism for capturing feature dependencies
- Configurable architecture (d_model, n_heads, n_layers, d_ff)
- Flexible pooling for aggregating sequence representations
- Standard framework integration with BaseModel interface
- Comprehensive gradient flow and architectural variation testing

🤖 Generated with [Claude Code](https://claude.ai/code)