### PR TITLE
Add NGBoost model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "torch",
     "numpy",
     "scikit-learn",
+    "ngboost>=0.5.6",
     "nflows",
     "torchdiffeq",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 torch
 numpy
 scikit-learn
+ngboost>=0.5.6
 nflows
 torchdiffeq

--- a/src/outdist/models/__init__.py
+++ b/src/outdist/models/__init__.py
@@ -47,6 +47,7 @@ from . import ckde  # noqa: F401
 from . import lincde  # noqa: F401
 from . import rfcde  # noqa: F401
 from . import logistic_mixture  # noqa: F401
+from . import ngboost_model  # noqa: F401
 from . import evidential  # noqa: F401
 from . import flow_cde  # noqa: F401
 from . import diffusion_cde  # noqa: F401

--- a/src/outdist/models/ngboost_model.py
+++ b/src/outdist/models/ngboost_model.py
@@ -1,0 +1,101 @@
+"""NGBoost wrapper for discrete-probability forecasting."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from sklearn.tree import DecisionTreeRegressor
+
+from . import register_model
+from ..configs.model import ModelConfig
+from ..data import binning as binning_scheme
+from .base import BaseModel
+
+try:  # Optional dependency
+    from ngboost import NGBRegressor
+    from ngboost.distns import Normal
+    from ngboost.scores import LogScore
+except Exception:  # pragma: no cover - optional dependency
+    NGBRegressor = None  # type: ignore
+    Normal = None  # type: ignore
+    LogScore = None  # type: ignore
+
+
+@register_model("ngboost")
+class NGBoostModel(BaseModel):
+    """Natural-Gradient Boosting returning per-bin logits."""
+
+    def __init__(
+        self,
+        start: float = 0.0,
+        end: float = 1.0,
+        n_bins: int = 10,
+        *,
+        Dist: str = "normal",
+        base_max_depth: int = 3,
+        n_estimators: int = 800,
+        learning_rate: float = 0.03,
+        minibatch_frac: float = 1.0,
+        verbose: bool = False,
+        binner: binning_scheme.BinningScheme | None = None,
+    ) -> None:
+        super().__init__()
+        if NGBRegressor is None:  # pragma: no cover - dependency not installed
+            raise ImportError("ngboost package is required for NGBoostModel")
+
+        dist_map = {"normal": Normal}
+        dist_cls = dist_map[Dist]
+
+        self.regressor = NGBRegressor(
+            Dist=dist_cls,
+            Base=DecisionTreeRegressor(max_depth=base_max_depth),
+            n_estimators=n_estimators,
+            learning_rate=learning_rate,
+            natural_gradient=True,
+            minibatch_frac=minibatch_frac,
+            verbose=verbose,
+            Score=LogScore,
+        )
+        if binner is None:
+            edges = torch.linspace(start, end, n_bins + 1)
+            binner = binning_scheme.BinningScheme(edges=edges)
+        self.binner = binner
+
+    # ------------------------------------------------------------------
+    def fit(self, x: torch.Tensor, y: torch.Tensor) -> "NGBoostModel":
+        """Fit the NGBoost ensemble."""
+        self.regressor.fit(x.detach().cpu().numpy(), y.detach().cpu().numpy())
+        return self
+
+    # ------------------------------------------------------------------
+    def predict_logits(self, x: torch.Tensor) -> torch.Tensor:
+        """Return log-probabilities for each fixed bin."""
+        edges = self.binner.edges.detach().cpu().numpy()
+        dist = self.regressor.pred_dist(x.detach().cpu().numpy())
+        cdf = np.vstack([d.cdf(edges) for d in dist])
+        probs = np.diff(cdf, axis=1) + 1e-12
+        logits = np.log(probs)
+        return torch.from_numpy(logits).to(x.device)
+
+    # ------------------------------------------------------------------
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.predict_logits(x)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def default_config() -> ModelConfig:
+        return ModelConfig(
+            name="ngboost",
+            params={
+                "start": 0.0,
+                "end": 1.0,
+                "n_bins": 10,
+                "Dist": "normal",
+                "base_max_depth": 3,
+                "n_estimators": 800,
+                "learning_rate": 0.03,
+                "minibatch_frac": 1.0,
+                "verbose": False,
+            },
+        )
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,7 +50,7 @@ def test_evaluate_cli_runs(tmp_path, monkeypatch):
     [
         n
         for n in MODEL_REGISTRY.keys()
-        if n not in {"ckde", "quantile_rf", "lincde", "rfcde"}
+        if n not in {"ckde", "quantile_rf", "lincde", "rfcde", "ngboost"}
     ],
 )
 def test_evaluate_cli_registered_models(name, tmp_path, monkeypatch):

--- a/tests/test_ngboost_model.py
+++ b/tests/test_ngboost_model.py
@@ -1,0 +1,32 @@
+import torch
+import pytest
+
+ngboost = pytest.importorskip("ngboost")
+
+from outdist.models import get_model
+from outdist.models.ngboost_model import NGBoostModel
+from outdist.configs.model import ModelConfig
+from outdist.data.binning import BinningScheme
+
+
+def test_ngboost_smoke():
+    X = torch.randn(20, 2)
+    y = torch.randn(20)
+    edges = torch.linspace(-1.0, 1.0, 6)
+    bins = BinningScheme(edges=edges)
+    model = get_model(
+        "ngboost",
+        start=-1.0,
+        end=1.0,
+        n_bins=5,
+        binner=bins,
+    )
+    model.fit(X, y)
+    logits = model.predict_logits(X)
+    assert logits.shape == (20, 5)
+
+
+def test_default_config_instantiates_ngboost():
+    cfg = NGBoostModel.default_config()
+    model = get_model(cfg)
+    assert isinstance(model, NGBoostModel)


### PR DESCRIPTION
## Summary
- add NGBoost wrapper model
- register new model
- depend on ngboost package
- skip NGBoost in CLI evaluate tests
- test basic NGBoost training/prediction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68772bde4a648324a08105768e3df7a4