### PR TITLE
Add synthetic-hard dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ from outdist import get_model, Trainer, make_dataset, ConsoleLogger
 from outdist.configs.trainer import TrainerConfig
 from outdist.data.binning import EqualWidthBinning
 
-# Create synthetic dataset
+# Create synthetic dataset (use ``"synthetic-hard"`` for a tougher variant)
 train_ds, val_ds, test_ds = make_dataset("synthetic", n_samples=200, n_features=3)
 
 # Set up model and binning
@@ -76,6 +76,8 @@ For quick experimentation, use the built-in CLI:
 
 ```bash
 python -m outdist.cli --model mlp --dataset synthetic --epochs 5
+# or try the harder variant
+python -m outdist.cli --model mlp --dataset synthetic-hard --epochs 5
 ```
 
 ## Available Models

--- a/tests/test_make_dataset.py
+++ b/tests/test_make_dataset.py
@@ -11,3 +11,10 @@ def test_synthetic_dataset_shapes():
     x, y = train_ds[0]
     assert x.shape == (4,)
     assert y.dim() == 0
+
+
+def test_synthetic_hard_dataset_shapes():
+    train_ds, _, _ = make_dataset("synthetic-hard", n_samples=30, n_features=3)
+    x, y = train_ds[0]
+    assert x.shape == (3,)
+    assert y.dim() == 0


### PR DESCRIPTION
## Summary
- create `synthetic-hard` dataset with pairwise feature interactions
- document usage of the harder dataset
- test dataset creation

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68773adc47ac8324a6951f5aae4691b6