### PR TITLE
Add epoch-level metric averages

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -20,7 +20,7 @@ class CountingLogger(TrainingLogger):
     ) -> None:
         self.batches += 1
 
-    def on_epoch_end(self, epoch: int, avg_loss: float) -> None:
+    def on_epoch_end(self, epoch: int, avg_loss: float, metrics: dict[str, float]) -> None:
         self.epochs += 1
         self.avgs.append(avg_loss)
 
@@ -48,7 +48,7 @@ class DummyCollectLogger(TrainingLogger):
         super().__init__()
         self.avgs = []
 
-    def on_epoch_end(self, epoch: int, avg_loss: float) -> None:
+    def on_epoch_end(self, epoch: int, avg_loss: float, metrics: dict[str, float]) -> None:
         self.avgs.append(avg_loss)
 
 


### PR DESCRIPTION
## Summary
- track metrics across an epoch in `TrainingLogger`
- print average metrics at the end of each epoch in `ConsoleLogger`
- update logger tests for new API

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687740bc094083248b3c392b1f6d020c