### PR TITLE
Implement spline transformer model

### DIFF
--- a/src/outdist/heads/__init__.py
+++ b/src/outdist/heads/__init__.py
@@ -1,0 +1,5 @@
+"""Head modules for output layers."""
+
+from .rqspline_head import RQSplineHead
+
+__all__ = ["RQSplineHead"]

--- a/src/outdist/heads/rqspline_head.py
+++ b/src/outdist/heads/rqspline_head.py
@@ -1,0 +1,66 @@
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+
+class RQSplineHead(nn.Module):
+    """Predicts a monotone rational--quadratic spline CDF."""
+
+    def __init__(self, in_dim: int, n_bins: int, n_knots: int = 8) -> None:
+        super().__init__()
+        self.n_bins = n_bins
+        self.n_knots = n_knots
+        out_dim = 3 * (n_knots + 1)  # widths, heights, slopes
+        self.proj = nn.Linear(in_dim, out_dim)
+
+    @staticmethod
+    def _rqs(x: torch.Tensor, cumx: torch.Tensor, cumy: torch.Tensor, d: torch.Tensor) -> torch.Tensor:
+        """Evaluate monotone rational quadratic spline at ``x``."""
+        widths = cumx[..., 1:] - cumx[..., :-1]
+        heights = cumy[..., 1:] - cumy[..., :-1]
+        delta = heights / widths
+
+        # Determine interval for each x
+        bin_idx = torch.searchsorted(cumx[..., 1:], x)
+        bin_idx = bin_idx.clamp(max=widths.size(-1) - 1)
+
+        input_cumx = cumx.gather(-1, bin_idx)
+        input_cumy = cumy.gather(-1, bin_idx)
+        input_widths = widths.gather(-1, bin_idx)
+        input_heights = heights.gather(-1, bin_idx)
+        input_delta = delta.gather(-1, bin_idx)
+        input_d = d.gather(-1, bin_idx)
+        input_d_plus_one = d.gather(-1, bin_idx + 1)
+
+        theta = (x - input_cumx) / input_widths
+        theta_one_minus_theta = theta * (1 - theta)
+
+        numerator = input_heights * (
+            input_delta * theta.pow(2) + input_d * theta_one_minus_theta
+        )
+        denominator = input_delta + (
+            (input_d + input_d_plus_one - 2 * input_delta) * theta_one_minus_theta
+        )
+        return input_cumy + numerator / denominator
+
+    def forward(self, h: torch.Tensor) -> torch.Tensor:
+        B = h.shape[0]
+        params = F.softplus(self.proj(h)) + 1e-4
+        w, h_, d = params.chunk(3, dim=-1)  # each (B, K+1)
+
+        # Normalise widths / heights to sum to 1
+        w = w / w.sum(-1, keepdim=True)
+        h_ = h_ / h_.sum(-1, keepdim=True)
+
+        # Cumulative knot coordinates in [0,1]
+        cumx = F.pad(torch.cumsum(w, dim=-1), (1, 0), value=0.0)
+        cumy = F.pad(torch.cumsum(h_, dim=-1), (1, 0), value=0.0)
+        d = F.pad(d, (1, 1), value=1.0)
+
+        # Evaluate spline CDF at all bin edges
+        edges = torch.linspace(0, 1, self.n_bins + 1, device=h.device)
+        edges = edges.unsqueeze(0).expand(B, -1)
+        F_edges = self._rqs(edges, cumx, cumy, d)
+
+        probs = F_edges[:, 1:] - F_edges[:, :-1]
+        return torch.log(probs.clamp_min(1e-8))

--- a/src/outdist/models/__init__.py
+++ b/src/outdist/models/__init__.py
@@ -59,3 +59,4 @@ from . import imm_jump  # noqa: F401
 from . import mean_flow  # noqa: F401
 from . import transformer  # noqa: F401
 from . import shortcut_cde_model  # noqa: F401
+from . import spline_transformer  # noqa: F401

--- a/src/outdist/models/spline_transformer.py
+++ b/src/outdist/models/spline_transformer.py
@@ -1,0 +1,69 @@
+"""Transformer encoder with spline-autoregressive head."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from .transformer import PositionalEncoding, TransformerBlock
+from .base import BaseModel
+from . import register_model
+from ..configs.model import ModelConfig
+from ..heads.rqspline_head import RQSplineHead
+
+
+@register_model("spline_transformer")
+class SplineTransformer(BaseModel):
+    """Transformer encoder followed by a spline head."""
+
+    def __init__(
+        self,
+        in_dim: int = 1,
+        n_bins: int = 10,
+        d_model: int = 64,
+        n_heads: int = 8,
+        n_layers: int = 2,
+        n_knots: int = 8,
+        dropout: float = 0.1,
+        pooling: str = "mean",
+        **_: object,
+    ) -> None:
+        super().__init__()
+        # ----- encoder -----------------------------------------------
+        self.input_embedding = nn.Linear(1, d_model)
+        self.pos_encoding = PositionalEncoding(d_model)
+        self.blocks = nn.ModuleList(
+            [TransformerBlock(d_model, n_heads, 4 * d_model, dropout) for _ in range(n_layers)]
+        )
+        self.pooling = pooling
+        # ----- spline head -------------------------------------------
+        self.head = RQSplineHead(d_model, n_bins, n_knots)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.input_embedding(x.unsqueeze(-1))
+        x = self.pos_encoding(x.transpose(0, 1)).transpose(0, 1)
+        for blk in self.blocks:
+            x = blk(x)
+        h = {
+            "mean": x.mean(1),
+            "max": x.max(1)[0],
+            "sum": x.sum(1),
+            "last": x[:, -1],
+        }[self.pooling]
+        return self.head(h)
+
+    @classmethod
+    def default_config(cls) -> ModelConfig:
+        return ModelConfig(
+            name="spline_transformer",
+            params=dict(
+                in_dim=1,
+                n_bins=10,
+                d_model=64,
+                n_heads=8,
+                n_layers=2,
+                n_knots=8,
+                dropout=0.1,
+                pooling="mean",
+            ),
+        )

--- a/tests/test_spline_transformer_model.py
+++ b/tests/test_spline_transformer_model.py
@@ -1,0 +1,30 @@
+import torch
+from outdist.models import get_model
+from outdist.models.spline_transformer import SplineTransformer
+
+
+def test_spline_transformer_forward_and_probs():
+    model = get_model(
+        "spline_transformer",
+        in_dim=3,
+        n_bins=5,
+        d_model=16,
+        n_heads=2,
+        n_layers=1,
+    )
+    x = torch.randn(4, 3)
+    logits = model(x)
+    assert logits.shape == (4, 5)
+
+    lp = torch.logsumexp(logits, dim=-1)
+    assert torch.allclose(lp, torch.zeros_like(lp), atol=1e-4)
+
+
+def test_default_config_instantiates_spline_transformer():
+    cfg = SplineTransformer.default_config()
+    model = get_model(cfg)
+    assert isinstance(model, SplineTransformer)
+    x = torch.randn(2, cfg.params["in_dim"])
+    logits = model(x)
+    assert logits.shape[1] == cfg.params["n_bins"]
+


### PR DESCRIPTION
## Summary
- implement `RQSplineHead` and create new `heads` package
- add `SplineTransformer` model using transformer encoder plus spline head
- register the new model
- test that the spline transformer outputs valid log probabilities

## Testing
- `pytest -q tests/test_spline_transformer_model.py`

------
https://chatgpt.com/codex/tasks/task_e_68797e48d74c83249cc8cc62ff531024