### PR TITLE
Add evaluator and metrics registry tests

### DIFF
--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,5 +1,5 @@
 import torch
-from outdist.evaluation.evaluator import cross_validate, CVFoldResult
+from outdist.evaluation.evaluator import cross_validate, CVFoldResult, _split_dataset
 from outdist.configs.model import ModelConfig
 from outdist.models import register_model, BaseModel
 from outdist.data.datasets import make_dataset
@@ -29,3 +29,36 @@ def test_cross_validate_runs():
     assert len(results) == 2
     assert all(isinstance(r, CVFoldResult) for r in results)
     assert all("nll" in r.metrics for r in results)
+
+
+def test_cross_validate_default_metrics():
+    """cross_validate should request default metrics when none provided."""
+    dataset, _, _ = make_dataset("synthetic", n_samples=20)
+
+    def model_factory():
+        return DummyModel(n_bins=10)
+
+    results = cross_validate(model_factory, dataset, k_folds=2)
+    assert all({"nll", "crps"}.issubset(r.metrics.keys()) for r in results)
+
+
+def test_split_dataset_even_and_uneven():
+    """_split_dataset should partition all indices exactly once."""
+    tensor_ds = torch.utils.data.TensorDataset(torch.arange(10))
+
+    # Even split into 5 folds -> each val set has 2 items
+    folds = list(_split_dataset(tensor_ds, 5))
+    assert len(folds) == 5
+    lengths = [len(val) for _, val in folds]
+    assert lengths == [2, 2, 2, 2, 2]
+
+    # Collect validation indices and ensure coverage
+    all_val_idx = sorted(i for _, val in folds for i in val.indices)
+    assert all_val_idx == list(range(10))
+
+    # Uneven split into 3 folds -> last fold gets remainder
+    folds = list(_split_dataset(tensor_ds, 3))
+    lengths = [len(val) for _, val in folds]
+    assert lengths == [3, 3, 4]
+    all_val_idx = sorted(i for _, val in folds for i in val.indices)
+    assert all_val_idx == list(range(10))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,5 @@
 import torch
-from outdist.metrics import nll, accuracy, crps
+from outdist.metrics import nll, accuracy, crps, METRICS_REGISTRY
 
 
 def test_nll_matches_cross_entropy():
@@ -55,3 +55,11 @@ def test_crps_float_targets():
     targets = torch.tensor([0.0, 1.0])  # float dtype
     score = crps(logits, targets)
     assert score >= 0.0
+
+
+def test_metrics_registry_contents():
+    """METRICS_REGISTRY should expose the expected metrics."""
+    assert METRICS_REGISTRY["nll"] is nll
+    assert METRICS_REGISTRY["accuracy"] is accuracy
+    assert METRICS_REGISTRY["crps"] is crps
+    assert set(METRICS_REGISTRY.keys()) == {"nll", "accuracy", "crps"}


### PR DESCRIPTION
## Summary
- exercise evaluator cross validation defaults and dataset splitting
- verify metrics registry entries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b71301e6c8324a2b5591e8ef3a0cf